### PR TITLE
Cre 705

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ properties([
 ])
 currentBuild.rawBuild.getParent().setQuietPeriod(0)
 
-library 'jenkins-pipeline-library@main'
+library 'jenkins-pipeline-library@CRE-705'
 
 builder.goapi([
   "validationGoVer": 'auto-v1.17.x',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,4 +46,4 @@ builder.goapi([
     }
     return permutations
   }
-])  
+]) 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ builder.goapi([
   "getTestPermutations": {
     List<List<String>> permutations = []
     for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.LINUX_MUSL, builder.DARWIN_X86_64,  builder.DARWIN_ARM]) {
-      for (gover in ['auto-v1.17.x']) {
+      for (gover in ['auto-latest', 'auto-previous']) {
         permutations << [platform, gover]
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,4 +47,3 @@ builder.goapi([
     return permutations
   }
 ])  
-

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,12 +22,23 @@ currentBuild.rawBuild.getParent().setQuietPeriod(0)
 
 library 'jenkins-pipeline-library@CRE-705'
 
+/*
+  Go Version examples:
+    auto-v1.17.x: Latest patch of 1.17 release
+    auto-v1.17.2: Specific patch of 1.17 release
+    auto-v1.17.0: First release of 1.17 (Despite go versioning this as 1.17)
+    auto-latest: Most recent patch version of latest minor release
+    auto-previous: Most recent patch version of previous minor release
+    auto-2previous: Most recent patch version of second last minor release
+
+  Adoption of new versions into these may be delayed.
+*/
 builder.goapi([
-  "validationGoVer": 'auto-v1.17.x',
   "buildCheckGoVer": 'auto-v1.17.x',
+  "validationGoVer": 'auto-v1.17.x',
   "getTestPermutations": {
     List<List<String>> permutations = []
-    for (platform in [builder.LINUX_ARM, builder.DARWIN_X86_64, builder.LINUX_X86_64, builder.DARWIN_ARM, builder.LINUX_MUSL]) {
+    for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.LINUX_MUSL, builder.DARWIN_X86_64,  builder.DARWIN_ARM]) {
       for (gover in ['auto-v1.17.x']) {
         permutations << [platform, gover]
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,7 @@ library 'jenkins-pipeline-library@CRE-705'
 
   Adoption of new versions into these may be delayed.
 */
+
 builder.goapi([
   "buildCheckGoVer": 'auto-v1.17.x',
   "validationGoVer": 'auto-v1.17.x',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,17 @@ currentBuild.rawBuild.getParent().setQuietPeriod(0)
 
 library 'jenkins-pipeline-library@main'
 
-stage('Build') {
-  builder.goapi()
-}
+builder.goapi([
+  "validationGoVer": 'auto-v1.17.x',
+  "buildCheckGoVer": 'auto-v1.17.x',
+  "getTestPermutations": {
+    List<List<String>> permutations = []
+    for (platform in [builder.LINUX_ARM, builder.DARWIN_X86_64, builder.LINUX_X86_64, builder.DARWIN_ARM, builder.LINUX_MUSL]) {
+      for (gover in ['auto-v1.17.x']) {
+        permutations << [platform, gover]
+      }
+    }
+    return permutations
+  }
+])  
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ properties([
 ])
 currentBuild.rawBuild.getParent().setQuietPeriod(0)
 
-library 'jenkins-pipeline-library@CRE-705'
+library 'jenkins-pipeline-library@main'
 
 /*
   Go Version examples:


### PR DESCRIPTION
Enables Developer driven pipeline test version updates. Changes have already been pushed to pipeline library main, this just adds the default values in the optional configuration map, and some docs.