### PR TITLE
Bug SOL-114567

### DIFF
--- a/internal/ccsmp/ccsmp_core.go
+++ b/internal/ccsmp/ccsmp_core.go
@@ -303,15 +303,15 @@ func (session *SolClientSession) SolClientSessionPublish(message SolClientMessag
 }
 
 // SolClientSessionSubscribe wraps solClient_session_topicSubscribeWithDispatch
-func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatchId uintptr,  correlationID uintptr) *SolClientErrorInfoWrapper {
+func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatchId uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
-		return C.SessionTopicSubscribe(session.pointer, 
-                                               cString,
-                                               C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
-                                               C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
+		return C.SessionTopicSubscribe(session.pointer,
+			cString,
+			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+			C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }
 
@@ -321,10 +321,10 @@ func (session *SolClientSession) SolClientSessionUnsubscribe(topic string, dispa
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
-		return C.SessionTopicUnsubscribe(session.pointer, 
-                                                 cString,
-                                                 C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
-                                                 C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
+		return C.SessionTopicUnsubscribe(session.pointer,
+			cString,
+			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+			C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }
 

--- a/internal/ccsmp/ccsmp_core.go
+++ b/internal/ccsmp/ccsmp_core.go
@@ -303,27 +303,27 @@ func (session *SolClientSession) SolClientSessionPublish(message SolClientMessag
 }
 
 // SolClientSessionSubscribe wraps solClient_session_topicSubscribeWithDispatch
-func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatchId uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
+func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatchID uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
 		return C.SessionTopicSubscribe(session.pointer,
 			cString,
-			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchID)),
 			C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }
 
 // SolClientSessionUnsubscribe wraps solClient_session_topicUnsubscribeWithDispatch
-func (session *SolClientSession) SolClientSessionUnsubscribe(topic string, dispatchId uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
+func (session *SolClientSession) SolClientSessionUnsubscribe(topic string, dispatchID uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
 		return C.SessionTopicUnsubscribe(session.pointer,
 			cString,
-			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+			C.uintptr_to_void_p(C.solClient_uint64_t(dispatchID)),
 			C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }

--- a/internal/ccsmp/ccsmp_core.go
+++ b/internal/ccsmp/ccsmp_core.go
@@ -303,22 +303,28 @@ func (session *SolClientSession) SolClientSessionPublish(message SolClientMessag
 }
 
 // SolClientSessionSubscribe wraps solClient_session_topicSubscribeWithDispatch
-func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatch *SolClientSessionRxMsgDispatchFuncInfo, correlationID uintptr) *SolClientErrorInfoWrapper {
+func (session *SolClientSession) SolClientSessionSubscribe(topic string, dispatchId uintptr,  correlationID uintptr) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
-		return C.solClient_session_topicSubscribeWithDispatch(session.pointer, C.SOLCLIENT_SUBSCRIBE_FLAGS_REQUEST_CONFIRM, cString, dispatch, C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
+		return C.SessionTopicSubscribe(session.pointer, 
+                                               cString,
+                                               C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+                                               C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }
 
 // SolClientSessionUnsubscribe wraps solClient_session_topicUnsubscribeWithDispatch
-func (session *SolClientSession) SolClientSessionUnsubscribe(topic string, dispatch *SolClientSessionRxMsgDispatchFuncInfo, correlationID uintptr) *SolClientErrorInfoWrapper {
+func (session *SolClientSession) SolClientSessionUnsubscribe(topic string, dispatchId uintptr, correlationID uintptr) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		cString := C.CString(topic)
 		defer C.free(unsafe.Pointer(cString))
 		// This is not an unsafe usage of unsafe.Pointer as we are using correlationId as data, not as a pointer
-		return C.solClient_session_topicUnsubscribeWithDispatch(session.pointer, C.SOLCLIENT_SUBSCRIBE_FLAGS_REQUEST_CONFIRM, cString, dispatch, C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
+		return C.SessionTopicUnsubscribe(session.pointer, 
+                                                 cString,
+                                                 C.uintptr_to_void_p(C.solClient_uint64_t(dispatchId)),
+                                                 C.uintptr_to_void_p(C.solClient_uint64_t(correlationID)))
 	})
 }
 

--- a/internal/ccsmp/ccsmp_helper.c
+++ b/internal/ccsmp/ccsmp_helper.c
@@ -15,8 +15,51 @@
 // limitations under the License.
 
 #include "./ccsmp_helper.h"
+#include "solclient/solClient.h"
+
+//
+// external callbacks defined in ccsmp_callbacks.c
+//
+solClient_rxMsgCallback_returnCode_t
+messageReceiveCallback(solClient_opaqueSession_pt opaqueSession_p, solClient_opaqueMsg_pt msg_p, void *user_p);
 
 void *uintptr_to_void_p(solClient_uint64_t ptr)
 {
     return (void *)ptr;
+}
+
+solClient_returnCode_t  SessionTopicSubscribe(
+                        solClient_opaqueSession_pt opaqueSession_p,
+                        const char                *topicSubscription_p,
+                        void                      *dispatchId_p,
+                        void                      *correlationTag_p) 
+{
+    solClient_session_rxMsgDispatchFuncInfo_t dispatchInfo;      /* msg dispatch callback to set */
+    dispatchInfo.dispatchType = SOLCLIENT_DISPATCH_TYPE_CALLBACK;
+    dispatchInfo.callback_p = messageReceiveCallback;
+    dispatchInfo.user_p = dispatchId_p;
+    dispatchInfo.rfu_p = NULL;
+    return solClient_session_topicSubscribeWithDispatch ( opaqueSession_p,
+                                                          SOLCLIENT_SUBSCRIBE_FLAGS_REQUEST_CONFIRM,
+                                                          topicSubscription_p,
+                                                          &dispatchInfo,
+                                                          correlationTag_p);
+}
+
+solClient_returnCode_t  SessionTopicUnsubscribe(
+                        solClient_opaqueSession_pt opaqueSession_p,
+                        const char                *topicSubscription_p,
+                        void                      *dispatchId_p,
+                        void                      *correlationTag_p) 
+{
+    solClient_session_rxMsgDispatchFuncInfo_t dispatchInfo;      /* msg dispatch callback to set */
+    dispatchInfo.dispatchType = SOLCLIENT_DISPATCH_TYPE_CALLBACK;
+    dispatchInfo.callback_p = messageReceiveCallback;
+    dispatchInfo.user_p = dispatchId_p;
+    dispatchInfo.rfu_p = NULL;
+    return solClient_session_topicUnsubscribeWithDispatch ( opaqueSession_p,
+                                                            SOLCLIENT_SUBSCRIBE_FLAGS_REQUEST_CONFIRM,
+                                                            topicSubscription_p,
+                                                            &dispatchInfo,
+                                                            correlationTag_p);
 }

--- a/internal/ccsmp/ccsmp_helper.h
+++ b/internal/ccsmp/ccsmp_helper.h
@@ -48,5 +48,15 @@ typedef struct solClient_errorInfo_wrapper
  */
 void *
 uintptr_to_void_p(solClient_uint64_t ptr);
+solClient_returnCode_t  SessionTopicSubscribe(
+                        solClient_opaqueSession_pt opaqueSession_p,
+                        const char                *topicSubscription_p,
+                        void                      *dispatchId_p,
+                        void                      *correlationTag_p);
+solClient_returnCode_t  SessionTopicUnsubscribe(
+                        solClient_opaqueSession_pt opaqueSession_p,
+                        const char                *topicSubscription_p,
+                        void                      *dispatchId_p,
+                        void                      *correlationTag_p);
 
 #endif

--- a/internal/impl/core/receiver.go
+++ b/internal/impl/core/receiver.go
@@ -108,7 +108,6 @@ type ccsmpBackedReceiver struct {
 	// TODO if performance becomes a concern, consider substituting maps and mutex for sync.Map
 	rxLock      sync.RWMutex
 	rxMap       map[uintptr]RxCallback
-	dispatchMap map[uintptr]*ccsmp.SolClientSessionRxMsgDispatchFuncInfo
 	dispatchID  uint64
 	//
 	subscriptionCorrelationLock sync.Mutex
@@ -125,7 +124,6 @@ func newCcsmpReceiver(session *ccsmp.SolClientSession, events *ccsmpBackedEvents
 	receiver.session = session
 	receiver.running = 0
 	receiver.rxMap = make(map[uintptr]RxCallback)
-	receiver.dispatchMap = make(map[uintptr]*ccsmp.SolClientSessionRxMsgDispatchFuncInfo)
 	receiver.dispatchID = 0
 	receiver.subscriptionCorrelation = make(map[SubscriptionCorrelationID]chan SubscriptionEvent)
 	receiver.subscriptionCorrelationID = 0
@@ -185,19 +183,17 @@ func (receiver *ccsmpBackedReceiver) rxCallback(msg Receivable, userP unsafe.Poi
 
 // Register an RX callback, returns a correlation pointer used when adding and removing subscriptions
 func (receiver *ccsmpBackedReceiver) RegisterRXCallback(msgCallback RxCallback) uintptr {
-	dispatch, dispatchPointer := ccsmp.NewSessionDispatch(atomic.AddUint64(&receiver.dispatchID, 1))
+	dispatchPointer := atomic.AddUint64(&receiver.dispatchID, 1)
 	receiver.rxLock.Lock()
 	defer receiver.rxLock.Unlock()
-	receiver.dispatchMap[dispatchPointer] = dispatch
-	receiver.rxMap[dispatchPointer] = msgCallback
-	return dispatchPointer
+	receiver.rxMap[uintptr(dispatchPointer)] = msgCallback
+	return uintptr(dispatchPointer)
 }
 
 // Remove the callback allowing GC to cleanup the function registered
 func (receiver *ccsmpBackedReceiver) UnregisterRXCallback(ptr uintptr) {
 	receiver.rxLock.Lock()
 	defer receiver.rxLock.Unlock()
-	delete(receiver.dispatchMap, ptr)
 	delete(receiver.rxMap, ptr)
 }
 
@@ -205,9 +201,8 @@ func (receiver *ccsmpBackedReceiver) UnregisterRXCallback(ptr uintptr) {
 func (receiver *ccsmpBackedReceiver) Subscribe(topic string, ptr uintptr) (SubscriptionCorrelationID, <-chan SubscriptionEvent, ErrorInfo) {
 	receiver.rxLock.RLock()
 	defer receiver.rxLock.RUnlock()
-	dispatch := receiver.dispatchMap[ptr]
 	id, c := receiver.newSubscriptionCorrelation()
-	errInfo := receiver.session.SolClientSessionSubscribe(topic, dispatch, id)
+	errInfo := receiver.session.SolClientSessionSubscribe(topic, ptr, id)
 	if errInfo != nil {
 		receiver.ClearSubscriptionCorrelation(id)
 		return 0, nil, errInfo
@@ -219,9 +214,8 @@ func (receiver *ccsmpBackedReceiver) Subscribe(topic string, ptr uintptr) (Subsc
 func (receiver *ccsmpBackedReceiver) Unsubscribe(topic string, ptr uintptr) (SubscriptionCorrelationID, <-chan SubscriptionEvent, ErrorInfo) {
 	receiver.rxLock.RLock()
 	defer receiver.rxLock.RUnlock()
-	dispatch := receiver.dispatchMap[ptr]
 	id, c := receiver.newSubscriptionCorrelation()
-	errInfo := receiver.session.SolClientSessionUnsubscribe(topic, dispatch, id)
+	errInfo := receiver.session.SolClientSessionUnsubscribe(topic, ptr, id)
 	if errInfo != nil {
 		receiver.ClearSubscriptionCorrelation(id)
 		return 0, nil, errInfo

--- a/internal/impl/core/receiver.go
+++ b/internal/impl/core/receiver.go
@@ -106,9 +106,9 @@ type ccsmpBackedReceiver struct {
 	session *ccsmp.SolClientSession
 	running int32
 	// TODO if performance becomes a concern, consider substituting maps and mutex for sync.Map
-	rxLock      sync.RWMutex
-	rxMap       map[uintptr]RxCallback
-	dispatchID  uint64
+	rxLock     sync.RWMutex
+	rxMap      map[uintptr]RxCallback
+	dispatchID uint64
 	//
 	subscriptionCorrelationLock sync.Mutex
 	subscriptionCorrelation     map[SubscriptionCorrelationID]chan SubscriptionEvent


### PR DESCRIPTION
dispatchMap and go declared C structure (solClient_session_rxMsgDispatchFuncInfo_t) with a pointer within appear to cause stack copying/memory moving problems with CGO.

dispatchMap is totally unnecessary, so remove it.  Move stack allocation of C datastructure to inside the C code, so we pass only primitives and uintptr between Go and C.