### PR TITLE
SOL-116360:  Fixed terminaton test

### DIFF
--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -1548,6 +1548,7 @@ var _ = Describe("PersistentReceiver", func() {
 	Describe("Unsolicited Termination Tests", func() {
 		var messagingService solace.MessagingService
 		var messageReceiver solace.PersistentMessageReceiver
+        const queueName = "unsolicitedPersistentTerminationQueue"
 
 		type unsolicitedTerminationContext struct {
 			terminateFunction func(messagingService solace.MessagingService,
@@ -1586,10 +1587,8 @@ var _ = Describe("PersistentReceiver", func() {
 			},
 			"queue delete": {
 				terminateFunction: func(messagingService solace.MessagingService, messageReceiver solace.PersistentMessageReceiver) {
-					receiverInfo, err := messageReceiver.ReceiverInfo()
-					Expect(err).ToNot(HaveOccurred())
-					_, _, err = testcontext.SEMP().Config().QueueApi.DeleteMsgVpnQueue(testcontext.SEMP().ConfigCtx(),
-						testcontext.Messaging().VPN, receiverInfo.GetResourceInfo().GetName())
+                    _, _, err := testcontext.SEMP().Config().QueueApi.DeleteMsgVpnQueue(testcontext.SEMP().ConfigCtx(),
+						testcontext.Messaging().VPN, queueName)
 					Expect(err).ToNot(HaveOccurred())
 				},
 				configuration: func() config.ServicePropertyMap {
@@ -1604,7 +1603,6 @@ var _ = Describe("PersistentReceiver", func() {
 			terminationCleanup := terminationContextRef.cleanupFunc
 			Context("using "+terminationCaseName, func() {
 				const topicString = "unsolicited-persistent-terminations"
-				const queueName = "unsolicitedPersistentTerminationQueue"
 				const numMessages = 5
 
 				var terminate func()
@@ -1683,19 +1681,46 @@ var _ = Describe("PersistentReceiver", func() {
 
 				It("handles unsolicited terminations while already terminating", func() {
 					blocker := make(chan struct{})
+                    signal := make(chan bool)
 					messageChannel := make(chan message.InboundMessage, numMessages+1)
+                    waitToReceiveMessages := 30 * time.Second // This timer needs to be big enough to give us a very
+                                                              // high chance of both receiving the messages and getting
+                                                              // past the state change in Terminate. It may need to be
+                                                              // updated in the future since this only mitigates the
+                                                              // race condition and doesn't eliminate it.
 					messageReceiver.ReceiveAsync(func(inboundMessage message.InboundMessage) {
+                        loop:
+                            for timeout := time.After(waitToReceiveMessages); ; {
+                                select {
+                                case <-timeout:
+                                    break loop
+                                default:
+                                }
+                                if !messageReceiver.IsRunning() {
+                                    break loop
+                                }
+                            }
+                        signal <- true
 						<-blocker
 						messageChannel <- inboundMessage
 					})
 					helpers.PublishNPersistentMessages(messagingService, topicString, numMessages+1)
 					helpers.ValidateMetric(messagingService, metrics.PersistentMessagesReceived, numMessages+1)
-					terminateDuration := 2 * time.Second
+                    terminateDuration := 2 * time.Second // This timer does not need to be especially long, since we're
+                                                         // only needed a fraction of a second to block on signal
+                                                         // and wait for that channel to be written to in the receiver
+                                                         // callback.
 					terminateChan := messageReceiver.TerminateAsync(terminateDuration)
+                    // Blocking on this signal prevents us from proceeding with the test unless either the timer has
+                    // expired or the state transition has occured.
+                    <-signal
+                    Expect(messageReceiver.IsRunning()).To(BeFalse())
+                    //Eventually(messageReceiver.IsRunning(), 5 * time.Second).Should(BeFalse())
 					terminationFunction(messagingService, messageReceiver)
 					Consistently(terminationReceived).ShouldNot(Receive())
 					time.Sleep(terminateDuration)
 					close(blocker)
+                    close(signal)
 					Eventually(terminateChan).Should(Receive())
 					helpers.ValidateMetric(messagingService, metrics.ReceivedMessagesTerminationDiscarded, numMessages)
 					Eventually(messageChannel).Should(Receive(Not(BeNil())))

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -1561,7 +1561,7 @@ var _ = Describe("PersistentReceiver", func() {
 	Describe("Unsolicited Termination Tests", func() {
 		var messagingService solace.MessagingService
 		var messageReceiver solace.PersistentMessageReceiver
-        const queueName = "unsolicitedPersistentTerminationQueue"
+		const queueName = "unsolicitedPersistentTerminationQueue"
 
 		type unsolicitedTerminationContext struct {
 			terminateFunction func(messagingService solace.MessagingService,
@@ -1600,7 +1600,7 @@ var _ = Describe("PersistentReceiver", func() {
 			},
 			"queue delete": {
 				terminateFunction: func(messagingService solace.MessagingService, messageReceiver solace.PersistentMessageReceiver) {
-                    _, _, err := testcontext.SEMP().Config().QueueApi.DeleteMsgVpnQueue(testcontext.SEMP().ConfigCtx(),
+					_, _, err := testcontext.SEMP().Config().QueueApi.DeleteMsgVpnQueue(testcontext.SEMP().ConfigCtx(),
 						testcontext.Messaging().VPN, queueName)
 					Expect(err).ToNot(HaveOccurred())
 				},
@@ -1694,46 +1694,45 @@ var _ = Describe("PersistentReceiver", func() {
 
 				It("handles unsolicited terminations while already terminating", func() {
 					blocker := make(chan struct{})
-                    signal := make(chan bool)
+					signal := make(chan bool)
 					messageChannel := make(chan message.InboundMessage, numMessages+1)
-                    waitToReceiveMessages := 30 * time.Second // This timer needs to be big enough to give us a very
-                                                              // high chance of both receiving the messages and getting
-                                                              // past the state change in Terminate. It may need to be
-                                                              // updated in the future since this only mitigates the
-                                                              // race condition and doesn't eliminate it.
+					waitToReceiveMessages := 30 * time.Second // This timer needs to be big enough to give us a very
+					// high chance of both receiving the messages and getting
+					// past the state change in Terminate. It may need to be
+					// updated in the future since this only mitigates the
+					// race condition and doesn't eliminate it.
 					messageReceiver.ReceiveAsync(func(inboundMessage message.InboundMessage) {
-                        loop:
-                            for timeout := time.After(waitToReceiveMessages); ; {
-                                select {
-                                case <-timeout:
-                                    break loop
-                                default:
-                                }
-                                if !messageReceiver.IsRunning() {
-                                    break loop
-                                }
-                            }
-                        signal <- true
+					loop:
+						for timeout := time.After(waitToReceiveMessages); ; {
+							select {
+							case <-timeout:
+								break loop
+							default:
+							}
+							if !messageReceiver.IsRunning() {
+								break loop
+							}
+						}
+						signal <- true
 						<-blocker
 						messageChannel <- inboundMessage
 					})
 					helpers.PublishNPersistentMessages(messagingService, topicString, numMessages+1)
 					helpers.ValidateMetric(messagingService, metrics.PersistentMessagesReceived, numMessages+1)
-                    terminateDuration := 2 * time.Second // This timer does not need to be especially long, since we're
-                                                         // only needed a fraction of a second to block on signal
-                                                         // and wait for that channel to be written to in the receiver
-                                                         // callback.
+					terminateDuration := 2 * time.Second // This timer does not need to be especially long, since we're
+					// only needed a fraction of a second to block on signal
+					// and wait for that channel to be written to in the receiver
+					// callback.
 					terminateChan := messageReceiver.TerminateAsync(terminateDuration)
-                    // Blocking on this signal prevents us from proceeding with the test unless either the timer has
-                    // expired or the state transition has occured.
-                    <-signal
-                    Expect(messageReceiver.IsRunning()).To(BeFalse())
-                    //Eventually(messageReceiver.IsRunning(), 5 * time.Second).Should(BeFalse())
+					// Blocking on this signal prevents us from proceeding with the test unless either the timer has
+					// expired or the state transition has occured.
+					<-signal
+					Expect(messageReceiver.IsRunning()).To(BeFalse())
 					terminationFunction(messagingService, messageReceiver)
 					Consistently(terminationReceived).ShouldNot(Receive())
 					time.Sleep(terminateDuration)
 					close(blocker)
-                    close(signal)
+					close(signal)
 					Eventually(terminateChan).Should(Receive())
 					helpers.ValidateMetric(messagingService, metrics.ReceivedMessagesTerminationDiscarded, numMessages)
 					Eventually(messageChannel).Should(Receive(Not(BeNil())))

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -1697,13 +1697,13 @@ var _ = Describe("PersistentReceiver", func() {
 					signal := make(chan bool)
 					messageChannel := make(chan message.InboundMessage, numMessages+1)
 
-                    // This timer needs to be big enough to give us a very
+					// This timer needs to be big enough to give us a very
 					// high chance of both receiving the messages and getting
 					// past the state change in Terminate. It may need to be
 					// updated in the future since this only mitigates the
 					// race condition and doesn't eliminate it.
 					waitToReceiveMessages := 30 * time.Second
-                    waitForTermination := waitToReceiveMessages
+					waitForTermination := waitToReceiveMessages
 					messageReceiver.ReceiveAsync(func(inboundMessage message.InboundMessage) {
 						signal <- true
 						<-blocker
@@ -1712,14 +1712,13 @@ var _ = Describe("PersistentReceiver", func() {
 					helpers.PublishNPersistentMessages(messagingService, topicString, numMessages+1)
 					helpers.ValidateMetric(messagingService, metrics.PersistentMessagesReceived, numMessages+1)
 					terminateDuration := 2 * time.Second
-                    Eventually(signal, waitToReceiveMessages).Should(Receive())
+					Eventually(signal, waitToReceiveMessages).Should(Receive())
 					terminateChan := messageReceiver.TerminateAsync(terminateDuration)
-                    Eventually(messageReceiver.IsRunning, waitForTermination).Should(BeFalse())
+					Eventually(messageReceiver.IsRunning, waitForTermination).Should(BeFalse())
 					Expect(messageReceiver.IsRunning()).To(BeFalse())
 					terminationFunction(messagingService, messageReceiver)
 					Consistently(terminationReceived).ShouldNot(Receive())
-                    Consistently(terminateChan).ShouldNot(Receive())
-					time.Sleep(terminateDuration)
+					Consistently(terminateChan, terminateDuration).ShouldNot(Receive())
 					close(blocker)
 					close(signal)
 					Eventually(terminateChan).Should(Receive())


### PR DESCRIPTION
Changed how queue is deleted so that the helper method uses data indepent of the receiver. Previoulsy this was causing an error because the helper method would occasionally illegally access the receiver's data after it had terminated due to a race condition. Other race conditions in the test such as checking the receiver's state before termination had begun has been mitigated through timers and blocking channel reads/writes. Refer to impl for details.