### PR TITLE
SOL-95364: 400 Invalid Queue Endpoint return code

### DIFF
--- a/test/helpers/resource_helpers.go
+++ b/test/helpers/resource_helpers.go
@@ -17,6 +17,11 @@
 package helpers
 
 import (
+	"strings"
+	"time"
+
+	"solace.dev/go/messaging/pkg/solace"
+	"solace.dev/go/messaging/pkg/solace/resource"
 	sempconfig "solace.dev/go/messaging/test/sempclient/config"
 	"solace.dev/go/messaging/test/sempclient/monitor"
 	"solace.dev/go/messaging/test/testcontext"
@@ -138,4 +143,58 @@ func GetQueueMessages(queueName string) []monitor.MsgVpnQueueMsg {
 	)
 	Expect(err).ToNot(HaveOccurred())
 	return response.Data
+}
+
+// GetQueues
+func GetQueues() []monitor.MsgVpnQueue {
+	response, _, err := testcontext.SEMP().Monitor().QueueApi.GetMsgVpnQueues(
+		testcontext.SEMP().MonitorCtx(),
+		testcontext.Messaging().VPN,
+		nil,
+	)
+	Expect(err).ToNot(HaveOccurred())
+	return response.Data
+}
+
+// GetHostName returns the hostname of the broker. If a messaging service is passes as non-nil, this function assumes
+// the service is connected, and creates a new persistent receiver and non-durable queue on the broker. It then
+// terminates the receiver, which cleans up the non-durable queue, and resolves the host name from a list of queues
+// queried from the broker. If a nil messging service is passed, this function assumes that the queues of interest to
+// the test already exist on the broker, and queries them to resolve the hostname without using API objects.
+func GetHostName(messagingService solace.MessagingService, queueName string) (string, bool) {
+	var hostName string
+	var queueList []monitor.MsgVpnQueue
+	if messagingService != nil {
+		receiver, err := messagingService.CreatePersistentMessageReceiverBuilder().Build(resource.QueueNonDurableExclusive(queueName))
+		if err != nil {
+			return "", false
+		}
+		err = receiver.Start()
+		if err != nil {
+			return "", false
+		}
+		queueList = GetQueues()
+		// We don't need to delete the queue in this case since a non durable queue will be destroyed on the broker once
+		// its associated flow is unbound
+		receiver.Terminate(0 * time.Second)
+	} else {
+		queueList = GetQueues()
+	}
+	retrievedQueueName := ""
+loop:
+	for i := range queueList {
+		if strings.Contains(queueList[i].QueueName, queueName) {
+			retrievedQueueName = queueList[i].QueueName
+			break loop
+		}
+	}
+	if retrievedQueueName == "" {
+		return "", false
+	}
+	const queuePrefix = "#P2P/QTMP/v:"
+	// This should be at the beginning, but just in case it's not, we still get the idx
+	first_half_idx := strings.Index(retrievedQueueName, queuePrefix) + len(queuePrefix)
+	second_half_idx := strings.Index(retrievedQueueName, "/"+queueName)
+	hostName = strings.TrimSpace(retrievedQueueName[first_half_idx:second_half_idx])
+	return hostName, false
 }

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -151,14 +151,18 @@ var _ = Describe("PersistentReceiver", func() {
 		})
 		Context("with a connected messaging service and specially formatted queue", func() {
 			const basicQueueName = "test_invalid_durability_on_bind_raises_exception"
-			modifiedQueueName := "#P2P/QTMP/v:solbroker/" + basicQueueName
+			var modifiedQueueName string
 
 			BeforeEach(func() {
 				helpers.ConnectMessagingService(messagingService)
+				foundHostName, _ := helpers.GetHostName(messagingService, basicQueueName)
+				modifiedQueueName = "#P2P/QTMP/v:" + foundHostName + "/" + basicQueueName
 				helpers.CreateQueue(modifiedQueueName)
 			})
 
 			AfterEach(func() {
+				foundHostName, _ := helpers.GetHostName(nil, basicQueueName)
+				modifiedQueueName = "#P2P/QTMP/v:" + foundHostName + "/" + basicQueueName
 				if messagingService.IsConnected() {
 					helpers.DisconnectMessagingService(messagingService)
 				}

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-    "log/slog"
     "net/url"
 
 	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
@@ -151,7 +150,6 @@ var _ = Describe("PersistentReceiver", func() {
 			Expect(fmt.Sprint(receiver)).To(ContainSubstring(fmt.Sprintf("%p", receiver)))
 		})
 		Context("with a connected messaging service and specially formatted queue", func() {
-            slog.SetLogLoggerLevel(slog.LevelDebug)
             const basicQueueName = "test_invalid_durability_on_bind_raises_exception"
             modifiedQueueName := "#P2P/QTMP/v:solbroker/" + basicQueueName
 

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -168,7 +168,7 @@ var _ = Describe("PersistentReceiver", func() {
 				helpers.DeleteQueue(url.QueryEscape(modifiedQueueName))
 			})
 
-            FDescribe("Invalid Queue or Topic Endpoint", func() {
+            Describe("Invalid Queue or Topic Endpoint", func() {
                 It("can return an error when configured to bind to a non-durable queue but attempts to bind to a durable queue.", func() {
                     fmt.Println("Got to It section")
                     receiver := helpers.NewPersistentReceiver(messagingService, resource.QueueNonDurableExclusive(basicQueueName))

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -156,7 +156,6 @@ var _ = Describe("PersistentReceiver", func() {
             modifiedQueueName := "#P2P/QTMP/v:solbroker/" + basicQueueName
 
 			BeforeEach(func() {
-                fmt.Println("Starting test")
 				helpers.ConnectMessagingService(messagingService)
 				helpers.CreateQueue(modifiedQueueName)
 			})
@@ -170,11 +169,9 @@ var _ = Describe("PersistentReceiver", func() {
 
             Describe("Invalid Queue or Topic Endpoint", func() {
                 It("can return an error when configured to bind to a non-durable queue but attempts to bind to a durable queue.", func() {
-                    fmt.Println("Got to It section")
                     receiver := helpers.NewPersistentReceiver(messagingService, resource.QueueNonDurableExclusive(basicQueueName))
                     err := receiver.Start()
                     Expect(err).ShouldNot(BeNil())
-                    fmt.Printf("err is: %s", err.Error())
                     helpers.ValidateNativeError(err, subcode.InvalidDurability)
                 })
             })

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -19,8 +19,8 @@ package test
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"time"
-    "net/url"
 
 	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 	. "github.com/onsi/ginkgo/v2"
@@ -150,8 +150,8 @@ var _ = Describe("PersistentReceiver", func() {
 			Expect(fmt.Sprint(receiver)).To(ContainSubstring(fmt.Sprintf("%p", receiver)))
 		})
 		Context("with a connected messaging service and specially formatted queue", func() {
-            const basicQueueName = "test_invalid_durability_on_bind_raises_exception"
-            modifiedQueueName := "#P2P/QTMP/v:solbroker/" + basicQueueName
+			const basicQueueName = "test_invalid_durability_on_bind_raises_exception"
+			modifiedQueueName := "#P2P/QTMP/v:solbroker/" + basicQueueName
 
 			BeforeEach(func() {
 				helpers.ConnectMessagingService(messagingService)
@@ -165,15 +165,15 @@ var _ = Describe("PersistentReceiver", func() {
 				helpers.DeleteQueue(url.QueryEscape(modifiedQueueName))
 			})
 
-            Describe("Invalid Queue or Topic Endpoint", func() {
-                It("can return an error when configured to bind to a non-durable queue but attempts to bind to a durable queue.", func() {
-                    receiver := helpers.NewPersistentReceiver(messagingService, resource.QueueNonDurableExclusive(basicQueueName))
-                    err := receiver.Start()
-                    Expect(err).ShouldNot(BeNil())
-                    helpers.ValidateNativeError(err, subcode.InvalidDurability)
-                })
-            })
-    })
+			Describe("Invalid Queue or Topic Endpoint", func() {
+				It("can return an error when configured to bind to a non-durable queue but attempts to bind to a durable queue.", func() {
+					receiver := helpers.NewPersistentReceiver(messagingService, resource.QueueNonDurableExclusive(basicQueueName))
+					err := receiver.Start()
+					Expect(err).ShouldNot(BeNil())
+					helpers.ValidateNativeError(err, subcode.InvalidDurability)
+				})
+			})
+		})
 
 		Context("with a connected messaging service and queue", func() {
 


### PR DESCRIPTION
Added test to verify that the CCSMP subcode 164 is mapped correctly and is passed to the application through an error when a persistent receiver tries to provision and bind to a non durable queue but uses the name of a pre-existing durable queue.
