### PR TITLE
SOL-59692: Provide Ability to NACK a Specific AD Message and Force Re-delivery

### DIFF
--- a/internal/ccsmp/ccsmp_flow.go
+++ b/internal/ccsmp/ccsmp_flow.go
@@ -45,6 +45,18 @@ type SolClientFlowEventInfoPt = C.solClient_flow_eventCallbackInfo_pt
 // SolClientFlowRxMsgDispatchFuncInfo is assigned a value
 type SolClientFlowRxMsgDispatchFuncInfo = C.solClient_flow_rxMsgDispatchFuncInfo_t
 
+// SolClientMessageSettlementOutcome is assigned a value
+type SolClientMessageSettlementOutcome = C.solClient_msgOutcome_t
+
+// SolClientSettlementOutcomeAccepted - the message was successfully processed.
+const SolClientSettlementOutcomeAccepted = C.SOLCLIENT_OUTCOME_ACCEPTED
+
+// SolClientSettlementOutcomeFailed - message processing failed temporarily, attempt redelivery if configured.
+const SolClientSettlementOutcomeFailed = C.SOLCLIENT_OUTCOME_FAILED
+
+// SolClientSettlementOutcomeRejected - message was processed and rejected, removed from the queue.
+const SolClientSettlementOutcomeRejected = C.SOLCLIENT_OUTCOME_REJECTED
+
 // Callbacks
 
 // SolClientFlowMessageCallback is assigned a function
@@ -171,6 +183,13 @@ func (flow *SolClientFlow) SolClientFlowUnsubscribe(topic string, correlationID 
 func (flow *SolClientFlow) SolClientFlowAck(msgID SolClientMessageID) *SolClientErrorInfoWrapper {
 	return handleCcsmpError(func() SolClientReturnCode {
 		return C.solClient_flow_sendAck(flow.pointer, msgID)
+	})
+}
+
+// SolClientFlowSettleMessage function
+func (flow *SolClientFlow) SolClientFlowSettleMessage(msgID SolClientMessageID, settlementOutcome SolClientMessageSettlementOutcome) *SolClientErrorInfoWrapper {
+	return handleCcsmpError(func() SolClientReturnCode {
+		return C.solClient_flow_settleMsg(flow.pointer, msgID, settlementOutcome)
 	})
 }
 

--- a/internal/impl/constants/error_strings.go
+++ b/internal/impl/constants/error_strings.go
@@ -70,6 +70,15 @@ const UnableToAcknowledgeAlreadyTerminated = "unable to acknowledge message: mes
 // UnableToAcknowledgeNotStarted error string
 const UnableToAcknowledgeNotStarted = "unable to acknowledge meessage: message receiver is not yet started"
 
+// UnableToSettleAlreadyTerminated error string
+const UnableToSettleAlreadyTerminated = "unable to settle message: message receiver has been terminated"
+
+// UnableToSettleNotStarted error string
+const UnableToSettleNotStarted = "unable to settle meessage: message receiver is not yet started"
+
+// InvalidMessageSettlementOutcome error string
+const InvalidMessageSettlementOutcome = "invalid message settlement outcome used to settle message"
+
 // UnableToModifySubscriptionBadState error string
 const UnableToModifySubscriptionBadState = "unable to modify subscriptions in state %s"
 

--- a/internal/impl/constants/error_strings.go
+++ b/internal/impl/constants/error_strings.go
@@ -64,12 +64,6 @@ const UnableToStartReceiver = "cannot start the receiver as it has already been 
 // UnableToStartReceiverParentServiceNotStarted error string
 const UnableToStartReceiverParentServiceNotStarted = "cannot start receiver unless parent MessagingService is connected"
 
-// UnableToAcknowledgeAlreadyTerminated error string
-const UnableToAcknowledgeAlreadyTerminated = "unable to acknowledge message: message receiver has been terminated"
-
-// UnableToAcknowledgeNotStarted error string
-const UnableToAcknowledgeNotStarted = "unable to acknowledge meessage: message receiver is not yet started"
-
 // UnableToSettleAlreadyTerminated error string
 const UnableToSettleAlreadyTerminated = "unable to settle message: message receiver has been terminated"
 

--- a/internal/impl/core/metrics.go
+++ b/internal/impl/core/metrics.go
@@ -178,7 +178,7 @@ func (backedMetrics *ccsmpBackedMetrics) GetStat(metric metrics.Metric) uint64 {
 	if rxMetric, ok := rxMetrics[metric]; ok {
 		// check for duplicate counts due to auto-acks and remove from final result
 		rxStat := backedMetrics.getRXStat(rxMetric)
-		duplicateAck := uint64(0)
+		duplicateAck := atomic.LoadUint64(&backedMetrics.duplicateAcks)
 		// take the difference and retrun as the settled accepted metric
 		if duplicateAck > 0 && metric == metrics.PersistentMessagesAccepted {
 			return rxStat - duplicateAck

--- a/internal/impl/core/metrics.go
+++ b/internal/impl/core/metrics.go
@@ -43,6 +43,9 @@ var rxMetrics = map[metrics.Metric]ccsmp.SolClientStatsRX{
 	metrics.TotalBytesReceived:                        ccsmp.SolClientStatsRXTotalDataBytes,
 	metrics.TotalMessagesReceived:                     ccsmp.SolClientStatsRXTotalDataMsgs,
 	metrics.CompressedBytesReceived:                   ccsmp.SolClientStatsRXCompressedBytes,
+	metrics.PersistentMessagesAccepted:                ccsmp.SolClientStatsRXSettleAccepted,
+	metrics.PersistentMessagesFailed:                  ccsmp.SolClientStatsRXSettleFailed,
+	metrics.PersistentMessagesRejected:                ccsmp.SolClientStatsRXSettleRejected,
 }
 
 var txMetrics = map[metrics.Metric]ccsmp.SolClientStatsTX{

--- a/internal/impl/core/metrics_test.go
+++ b/internal/impl/core/metrics_test.go
@@ -60,9 +60,4 @@ func TestIncrementDuplicateAckCount(t *testing.T) {
 	if duplicateAck != 11 {
 		t.Error("Expected duplicate Acks to be 11")
 	}
-	metricsImpl.ResetStats() // reset all stats
-	duplicateAck = atomic.LoadUint64(&metricsImpl.duplicateAcks)
-	if duplicateAck != 0 {
-		t.Error("Expected state of duplicate Acks counter to be 0 after calling Reset()")
-	}
 }

--- a/internal/impl/core/receiver.go
+++ b/internal/impl/core/receiver.go
@@ -65,8 +65,10 @@ type Receiver interface {
 	ProvisionEndpoint(queueName string, isExclusive bool) ErrorInfo
 	// EndpointUnsubscribe will call endpoint unsubscribe on the endpoint
 	EndpointUnsubscribe(queueName string, topic string) (SubscriptionCorrelationID, <-chan SubscriptionEvent, ErrorInfo)
-	// Increments receiver metrics
+	// IncrementMetric - Increments receiver metrics
 	IncrementMetric(metric NextGenMetric, amount uint64)
+	// IncrementDuplicateAckCount - Increments receiver duplicate acks (track duplicate accepted settlement outcome metrics from auto-acks)
+	IncrementDuplicateAckCount()
 	// Creates a new persistent receiver with the given callback
 	NewPersistentReceiver(properties []string, callback RxCallback, eventCallback PersistentEventCallback) (PersistentReceiver, ErrorInfo)
 }
@@ -287,6 +289,10 @@ func getEndpointProperties(queueName string) []string {
 
 func (receiver *ccsmpBackedReceiver) IncrementMetric(metric NextGenMetric, amount uint64) {
 	receiver.metrics.IncrementMetric(metric, amount)
+}
+
+func (receiver *ccsmpBackedReceiver) IncrementDuplicateAckCount() {
+	receiver.metrics.incrementDuplicateAckCount()
 }
 
 func (receiver *ccsmpBackedReceiver) ClearSubscriptionCorrelation(id SubscriptionCorrelationID) {

--- a/internal/impl/receiver/message_receiver_impl_test.go
+++ b/internal/impl/receiver/message_receiver_impl_test.go
@@ -378,6 +378,7 @@ type mockPersistentReceiver struct {
 	subscribe   func(topic string) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
 	unsubscribe func(topic string) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
 	ack         func(msg core.MessageID) *ccsmp.SolClientErrorInfoWrapper
+	settle      func(msg core.MessageID, outcome core.MessageSettlementOutcome) *ccsmp.SolClientErrorInfoWrapper
 }
 
 // Destroy destroys the flow
@@ -425,6 +426,14 @@ func (mock *mockPersistentReceiver) Unsubscribe(topic string) (core.Subscription
 func (mock *mockPersistentReceiver) Ack(msgID core.MessageID) *ccsmp.SolClientErrorInfoWrapper {
 	if mock.ack != nil {
 		return mock.ack(msgID)
+	}
+	return nil
+}
+
+// Settle will settle the given message with the provided outcome
+func (mock *mockPersistentReceiver) Settle(msgID core.MessageID, outcome core.MessageSettlementOutcome) *ccsmp.SolClientErrorInfoWrapper {
+	if mock.settle != nil {
+		return mock.settle(msgID, outcome)
 	}
 	return nil
 }

--- a/internal/impl/receiver/message_receiver_impl_test.go
+++ b/internal/impl/receiver/message_receiver_impl_test.go
@@ -283,15 +283,16 @@ type result struct {
 }
 
 type mockInternalReceiver struct {
-	events                func() core.Events
-	replier               func() core.Replier
-	isRunning             func() bool
-	registerRxCallback    func(callback core.RxCallback) uintptr
-	unregisterRxCallback  func(ptr uintptr)
-	subscribe             func(topic string, ptr uintptr) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
-	unsubscribe           func(topic string, ptr uintptr) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
-	incrementMetric       func(metric core.NextGenMetric, amount uint64)
-	newPersistentReceiver func(props []string, callback core.RxCallback, eventCallback core.PersistentEventCallback) (core.PersistentReceiver, *ccsmp.SolClientErrorInfoWrapper)
+	events                     func() core.Events
+	replier                    func() core.Replier
+	isRunning                  func() bool
+	registerRxCallback         func(callback core.RxCallback) uintptr
+	unregisterRxCallback       func(ptr uintptr)
+	subscribe                  func(topic string, ptr uintptr) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
+	unsubscribe                func(topic string, ptr uintptr) (core.SubscriptionCorrelationID, <-chan core.SubscriptionEvent, core.ErrorInfo)
+	incrementMetric            func(metric core.NextGenMetric, amount uint64)
+	incrementDuplicateAckCount func()
+	newPersistentReceiver      func(props []string, callback core.RxCallback, eventCallback core.PersistentEventCallback) (core.PersistentReceiver, *ccsmp.SolClientErrorInfoWrapper)
 }
 
 func (mock *mockInternalReceiver) Events() core.Events {
@@ -361,6 +362,12 @@ func (mock *mockInternalReceiver) EndpointUnsubscribe(queueName string, topic st
 func (mock *mockInternalReceiver) IncrementMetric(metric core.NextGenMetric, amount uint64) {
 	if mock.incrementMetric != nil {
 		mock.incrementMetric(metric, amount)
+	}
+}
+
+func (mock *mockInternalReceiver) IncrementDuplicateAckCount() {
+	if mock.incrementDuplicateAckCount != nil {
+		mock.incrementDuplicateAckCount()
 	}
 }
 

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -1373,9 +1373,9 @@ func (builder *persistentMessageReceiverBuilderImpl) Build(queue *resource.Queue
 					// add the corresponding ccsmp property to the properties array
 					switch config.MessageSettlementOutcome(settlementOutcome) {
 					case config.PersistentReceiverFailedOutcome:
-						properties = append(properties, ccsmp.SolClientFlowPropRequiredOutcomeFailed, settlementOutcome)
+						properties = append(properties, ccsmp.SolClientFlowPropRequiredOutcomeFailed, ccsmp.SolClientPropEnableVal)
 					case config.PersistentReceiverRejectedOutcome:
-						properties = append(properties, ccsmp.SolClientFlowPropRequiredOutcomeRejected, settlementOutcome)
+						properties = append(properties, ccsmp.SolClientFlowPropRequiredOutcomeRejected, ccsmp.SolClientPropEnableVal)
 					case config.PersistentReceiverAcceptedOutcome:
 					default:
 						logging.Default.Info(builder.String() + ": Receiver message settlement outcome of 'ACCEPTED' is supported by default")

--- a/pkg/solace/config/message_receiver_properties.go
+++ b/pkg/solace/config/message_receiver_properties.go
@@ -86,6 +86,9 @@ const (
 	// ReceiverPropertyPersistentMessageAckStrategy specifies the acknowledgement strategy for the message receiver.
 	ReceiverPropertyPersistentMessageAckStrategy ReceiverProperty = "solace.messaging.receiver.persistent.ack.strategy"
 
+	// ReceiverPropertyPersistentMessageRequiredOutcomeSupport for configuring the settlement outcomes for the message receiver.
+	ReceiverPropertyPersistentMessageRequiredOutcomeSupport ReceiverProperty = "solace.messaging.receiver.persistent.ack.required-message-outcome-support"
+
 	// ReceiverPropertyPersistentMessageReplayStrategy enables message replay and to specify a replay strategy.
 	ReceiverPropertyPersistentMessageReplayStrategy ReceiverProperty = "solace.messaging.receiver.persistent.replay.strategy"
 

--- a/pkg/solace/config/messaging_receiver_constants.go
+++ b/pkg/solace/config/messaging_receiver_constants.go
@@ -16,7 +16,7 @@
 
 package config
 
-// Represents the type for supported message settlement outcome on a PersistentMessageReceiver.
+// MessageSettlementOutcome - represents the type for supported message settlement outcome on a PersistentMessageReceiver.
 type MessageSettlementOutcome string
 
 // The various message settlement outcomes available for use when configuring a PersistentMessageReceiver.

--- a/pkg/solace/config/messaging_receiver_constants.go
+++ b/pkg/solace/config/messaging_receiver_constants.go
@@ -1,0 +1,34 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+// Represents the type for supported message settlement outcome on a PersistentMessageReceiver.
+type MessageSettlementOutcome string
+
+// The various message settlement outcomes available for use when configuring a PersistentMessageReceiver.
+const (
+	// Settles the message with a positive acknowledgement, removing it from the queue.
+	// Same as calling Ack() on the message.
+	PersistentReceiverAcceptedOutcome MessageSettlementOutcome = "ACCEPTED"
+
+	// Settles the message with a negative acknowledgement without removing it from the queue.
+	// This may or may not make the message eligible for redelivery or eventually the DMQ, depending on the queue configuration.
+	PersistentReceiverFailedOutcome MessageSettlementOutcome = "FAILED"
+
+	// Settles the message with a negative acknowledgement, removing it from the queue.
+	PersistentReceiverRejectedOutcome MessageSettlementOutcome = "REJECTED"
+)

--- a/pkg/solace/metrics/metrics.go
+++ b/pkg/solace/metrics/metrics.go
@@ -110,6 +110,15 @@ const (
 	// persistent message receivers on the MessagingService.
 	PersistentOutOfOrderMessagesDiscarded
 
+	// Number of messages settled with "ACCEPTED" outcome.
+	PersistentMessagesAccepted
+
+	// Number of messages settled with "FAILED" outcome.
+	PersistentMessagesFailed
+
+	// Number of messages settled with "REJECTED" outcome.
+	PersistentMessagesRejected
+
 	// PublishMessagesDiscarded is the number of messages discarded due to
 	// channel failure.
 	PublishMessagesDiscarded

--- a/pkg/solace/persistent_message_receiver.go
+++ b/pkg/solace/persistent_message_receiver.go
@@ -113,6 +113,12 @@ type PersistentMessageReceiverBuilder interface {
 	// to when starting the receiver. Accepts *resource.TopicSubscription subscriptions.
 	WithSubscriptions(topics ...resource.Subscription) PersistentMessageReceiverBuilder
 
+	// WithRequiredMessageOutcomeSupport configures the types of settlements the receiver can use.
+	// Any combination of PersistentReceiverAcceptedOutcome, PersistentReceiverFailedOutcome, and
+	// PersistentReceiverRejectedOutcome; the order is irrelevant.
+	// Attempting to Settle() a message later with an Outcome not listed here may result in an error.
+	WithRequiredMessageOutcomeSupport(messageSettlementOutcomes ...config.MessageSettlementOutcome) PersistentMessageReceiverBuilder
+
 	// FromConfigurationProvider configures the persistent receiver with the specified properties.
 	// The built-in ReceiverPropertiesConfigurationProvider implementations include:
 	//   ReceiverPropertyMap, a map of ReceiverProperty keys to values

--- a/pkg/solace/persistent_message_receiver.go
+++ b/pkg/solace/persistent_message_receiver.go
@@ -29,7 +29,17 @@ type PersistentMessageReceiver interface {
 	MessageReceiver // Include all functionality of MessageReceiver.
 
 	// Ack acknowledges that a  message was received.
+	// This method is equivalent to calling the settle method with
+	// the ACCEPTED outcome like this: PersistentMessageReceiver.Settle(inboundMessage, config.PersistentReceiverAcceptedOutcome)
 	Ack(message message.InboundMessage) error
+
+	// Settle generates and sends a positive or negative acknowledgement for a message.InboundMessage as
+	// indicated by the MessageSettlementOutcome argument. To use the negative outcomes FAILED and REJECTED,
+	// the receiver has to have been preconfigured via its builder to support these settlement outcomes.
+	// Attempts to settle a message on an auto-acking receiver is ignored for ACCEPTED
+	// (albeit it counts as a manual ACCEPTED in the stats), raises error for FAILED and REJECTED.
+	// this returns an error object with the reason for the error if it was not possible to settle the message.
+	Settle(message message.InboundMessage, outcome config.MessageSettlementOutcome) error
 
 	// StartAsyncCallback starts the PersistentMessageReceiver asynchronously.
 	// Calls the callback when started with an error if one occurred, otherwise nil

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -301,7 +301,7 @@ var _ = Describe("PersistentReceiver", func() {
 						err := receiver.Ack(nil)
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
-					DescribeTable("should fail to settle a message as ",
+					DescribeTable("should fail to settle a nil message as ",
 						func(outcome config.MessageSettlementOutcome) {
 							err := receiver.Settle(nil, outcome)
 							helpers.ValidateError(err, &solace.IllegalStateError{})
@@ -309,9 +309,8 @@ var _ = Describe("PersistentReceiver", func() {
 						Entry("accepted", config.PersistentReceiverAcceptedOutcome),
 						Entry("rejected", config.PersistentReceiverRejectedOutcome),
 						Entry("failed", config.PersistentReceiverFailedOutcome),
-						//Entry("garbage", "garbage"),
 					)
-					It("should fail to settle a message with garbage", func() {
+					It("should fail to settle a nil message with garbage", func() {
 						err := receiver.Settle(nil, "garbage")
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
@@ -344,11 +343,11 @@ var _ = Describe("PersistentReceiver", func() {
 						err := receiver.Pause()
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
-					It("should fail to acknowledge a message", func() {
+					It("should fail to acknowledge a nil message", func() {
 						err := receiver.Ack(nil)
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
-					DescribeTable("should fail to settle a message as ",
+					DescribeTable("should fail to settle a nil message as ",
 						func(outcome config.MessageSettlementOutcome) {
 							err := receiver.Settle(nil, outcome)
 							helpers.ValidateError(err, &solace.IllegalStateError{})
@@ -356,9 +355,8 @@ var _ = Describe("PersistentReceiver", func() {
 						Entry("accepted", config.PersistentReceiverAcceptedOutcome),
 						Entry("rejected", config.PersistentReceiverRejectedOutcome),
 						Entry("failed", config.PersistentReceiverFailedOutcome),
-						//Entry("garbage", "garbage"),
 					)
-					It("should fail to settle a message with garbage", func() {
+					It("should fail to settle a nil message with garbage", func() {
 						err := receiver.Settle(nil, "garbage")
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
@@ -848,7 +846,6 @@ var _ = Describe("PersistentReceiver", func() {
 				Entry("accepted", config.PersistentReceiverAcceptedOutcome),
 				Entry("rejected", config.PersistentReceiverRejectedOutcome),
 				Entry("failed", config.PersistentReceiverFailedOutcome),
-				//Entry("garbage", "garbage"),
 				)
 				It("fails to settle a direct message as garbage", func() {
 					const topic = "direct-message-ack"
@@ -1433,19 +1430,26 @@ var _ = Describe("PersistentReceiver", func() {
 			// I don't think the setter should accept garbage.
 			It("Garbage to setter", func() {
 				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
-				receiverBuilder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome, "garbage")
+				receiverBuilder.WithRequiredMessageOutcomeSupport("garbage")
 				receiver, err := receiverBuilder.Build(resource.QueueDurableExclusive(queueName))
 				helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				Expect(receiver).To(BeNil())
 			})
 			It("Legit outcome mixed with garbage to setter", func() {
 				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
-				receiverBuilder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome, "garbage")
+				receiverBuilder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome, "garbage")
 				receiver, err := receiverBuilder.Build(resource.QueueDurableExclusive(queueName))
 				helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				Expect(receiver).To(BeNil())
 			})
-			FIt("Garbage as property", func() {
+			It("Legit outcome mixed with garbage to setter backwards", func() {
+				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
+				receiverBuilder.WithRequiredMessageOutcomeSupport("garbage", config.PersistentReceiverFailedOutcome)
+				receiver, err := receiverBuilder.Build(resource.QueueDurableExclusive(queueName))
+				helpers.ValidateError(err, &solace.IllegalArgumentError{})
+				Expect(receiver).To(BeNil())
+			})
+			It("Garbage as property", func() {
 				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
 				receiverBuilder.FromConfigurationProvider(config.ReceiverPropertyMap{
 					config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: "garbage",
@@ -1454,7 +1458,7 @@ var _ = Describe("PersistentReceiver", func() {
 				helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				Expect(receiver).To(BeNil())
 			})
-			FIt("Garbage mixed in as property", func() {
+			It("Garbage mixed in as property", func() {
 				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
 				receiverBuilder.FromConfigurationProvider(config.ReceiverPropertyMap{
 					config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,garbage",config.PersistentReceiverRejectedOutcome),
@@ -1463,7 +1467,7 @@ var _ = Describe("PersistentReceiver", func() {
 				helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				Expect(receiver).To(BeNil())
 			})
-			FIt("Poor punctuation in property", func() {
+			It("Poor punctuation in property", func() {
 				receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
 				receiverBuilder.FromConfigurationProvider(config.ReceiverPropertyMap{
 					config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s %s",config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome),

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -829,13 +829,31 @@ var _ = Describe("PersistentReceiver", func() {
 					err := receiver.Ack(directMsg)
 					helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				})
-				It("fails to settle a direct message", func() {
+				It("fails to settle a direct message as rejected", func() {
 					const topic = "direct-message-ack"
 					directMsgChan := helpers.ReceiveOneMessage(messagingService, topic)
 					helpers.PublishOneMessage(messagingService, topic)
 					var directMsg message.InboundMessage
 					Eventually(directMsgChan).Should(Receive(&directMsg))
 					err := receiver.Settle(directMsg, config.PersistentReceiverRejectedOutcome) // should fail to settle message
+					helpers.ValidateError(err, &solace.IllegalArgumentError{})
+				})
+				It("fails to settle a direct message as failed", func() {
+					const topic = "direct-message-ack"
+					directMsgChan := helpers.ReceiveOneMessage(messagingService, topic)
+					helpers.PublishOneMessage(messagingService, topic)
+					var directMsg message.InboundMessage
+					Eventually(directMsgChan).Should(Receive(&directMsg))
+					err := receiver.Settle(directMsg, config.PersistentReceiverFailedOutcome) // should fail to settle message
+					helpers.ValidateError(err, &solace.IllegalArgumentError{})
+				})
+				It("fails to settle a direct message as accepted", func() {
+					const topic = "direct-message-ack"
+					directMsgChan := helpers.ReceiveOneMessage(messagingService, topic)
+					helpers.PublishOneMessage(messagingService, topic)
+					var directMsg message.InboundMessage
+					Eventually(directMsgChan).Should(Receive(&directMsg))
+					err := receiver.Settle(directMsg, config.PersistentReceiverAcceptedOutcome) // should fail to settle message
 					helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				})
 			})

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -845,9 +845,9 @@ var _ = Describe("PersistentReceiver", func() {
 					err := receiver.Settle(directMsg, outcome) // should fail to settle message
 					helpers.ValidateError(err, &solace.IllegalArgumentError{})
 				},
-				Entry("accepted", config.PersistentReceiverAcceptedOutcome),
-				Entry("rejected", config.PersistentReceiverRejectedOutcome),
-				Entry("failed", config.PersistentReceiverFailedOutcome),
+					Entry("accepted", config.PersistentReceiverAcceptedOutcome),
+					Entry("rejected", config.PersistentReceiverRejectedOutcome),
+					Entry("failed", config.PersistentReceiverFailedOutcome),
 				//Entry("garbage", "garbage"),
 				)
 				It("fails to settle a direct message as garbage", func() {
@@ -1259,17 +1259,18 @@ var _ = Describe("PersistentReceiver", func() {
 				Expect(receiver.Terminate(10 * time.Second)).ToNot(HaveOccurred())
 			})
 
-
 			for _, autoAck := range []bool{true, false} {
 				autoAckText := ""
 				// ??? I don't speak go, so I'm just rolling with it.
-				autoAck2 := autoAck
-				if autoAck {autoAckText = " withAutoAck"}
-				DescribeTable("Happy cases for outcome configuration on ReceiverBuilder" + autoAckText,
-					func(configFunc func(solace.PersistentMessageReceiverBuilder), outcome config.MessageSettlementOutcome) {
+				shouldAutoAck := autoAck
+				if autoAck {
+					autoAckText = " withAutoAck"
+				}
+				DescribeTable("Happy cases for outcome configuration on ReceiverBuilder"+autoAckText,
+					func(configFunc func(solace.PersistentMessageReceiverBuilder), outcome config.MessageSettlementOutcome, autoAckConfig bool) {
 						receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
 						configFunc(receiverBuilder)
-						if autoAck2 {
+						if autoAckConfig {
 							receiverBuilder.WithMessageAutoAcknowledgement()
 						}
 						receiver, err := receiverBuilder.Build(resource.QueueDurableExclusive(queueName))
@@ -1285,25 +1286,25 @@ var _ = Describe("PersistentReceiver", func() {
 
 						err = receiver.Settle(msg, outcome)
 						Expect(err).ToNot(HaveOccurred())
-						/* if (autoAck2) {
+						/* if (autoAckConfig) {
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesAccepted, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesRejected, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesFailed, 0)
-						} else */ if (outcome == config.PersistentReceiverAcceptedOutcome) {
+						} else */if outcome == config.PersistentReceiverAcceptedOutcome {
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesAccepted, 1)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesRejected, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesFailed, 0)
-						} else if (outcome == config.PersistentReceiverRejectedOutcome) {
+						} else if outcome == config.PersistentReceiverRejectedOutcome {
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesAccepted, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesRejected, 1)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesFailed, 0)
-						} else if (outcome == config.PersistentReceiverFailedOutcome) {
+						} else if outcome == config.PersistentReceiverFailedOutcome {
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesAccepted, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesRejected, 0)
 							helpers.ValidateMetric(messagingService, metrics.PersistentMessagesFailed, 1)
 						}
 						// I guess this drains the queue?
-						if (!autoAck2 && outcome == config.PersistentReceiverFailedOutcome){
+						if !autoAckConfig && outcome == config.PersistentReceiverFailedOutcome {
 							Consistently(
 								func() []monitor.MsgVpnQueueMsg {
 									return helpers.GetQueueMessages(queueName)
@@ -1313,120 +1314,118 @@ var _ = Describe("PersistentReceiver", func() {
 					},
 					Entry(
 						"Default can Accept", func(builder solace.PersistentMessageReceiverBuilder) {},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept via setter", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverAcceptedOutcome)
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Fail via setter can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome)
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Fail via setter can fail", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome)
 						},
-						config.PersistentReceiverFailedOutcome),
+						config.PersistentReceiverFailedOutcome, shouldAutoAck),
 					Entry(
 						"Fail via setter can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome)
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Fail via setter can fail", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverFailedOutcome)
 						},
-						config.PersistentReceiverFailedOutcome),
+						config.PersistentReceiverFailedOutcome, shouldAutoAck),
 					Entry(
 						"Accept via property", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s",config.PersistentReceiverAcceptedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s", config.PersistentReceiverAcceptedOutcome),
 							})
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Fail via property can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s",config.PersistentReceiverFailedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s", config.PersistentReceiverFailedOutcome),
 							})
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Fail via property can fail", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s",config.PersistentReceiverFailedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s", config.PersistentReceiverFailedOutcome),
 							})
 						},
-						config.PersistentReceiverFailedOutcome),
+						config.PersistentReceiverFailedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Fail via property can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s",config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s", config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome),
 							})
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Fail via property can fail", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s",config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s", config.PersistentReceiverFailedOutcome, config.PersistentReceiverAcceptedOutcome),
 							})
 						},
-						config.PersistentReceiverFailedOutcome),
-
+						config.PersistentReceiverFailedOutcome, shouldAutoAck),
 
 					Entry(
 						"Accept & Reject via setter can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome)
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Reject via setter can reject", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome)
 						},
-						config.PersistentReceiverRejectedOutcome),
+						config.PersistentReceiverRejectedOutcome, shouldAutoAck),
 					Entry(
 						"Reject via setter can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverRejectedOutcome)
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Reject via setter can reject", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.WithRequiredMessageOutcomeSupport(config.PersistentReceiverRejectedOutcome)
 						},
-						config.PersistentReceiverRejectedOutcome),
+						config.PersistentReceiverRejectedOutcome, shouldAutoAck),
 					Entry(
 						"Reject via property can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s",config.PersistentReceiverRejectedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s", config.PersistentReceiverRejectedOutcome),
 							})
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Reject via property can reject", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s",config.PersistentReceiverRejectedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s", config.PersistentReceiverRejectedOutcome),
 							})
 						},
-						config.PersistentReceiverRejectedOutcome),
+						config.PersistentReceiverRejectedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Reject via property can accept", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s",config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s", config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome),
 							})
 						},
-						config.PersistentReceiverAcceptedOutcome),
+						config.PersistentReceiverAcceptedOutcome, shouldAutoAck),
 					Entry(
 						"Accept & Reject via property can reject", func(builder solace.PersistentMessageReceiverBuilder) {
 							builder.FromConfigurationProvider(config.ReceiverPropertyMap{
-								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s",config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome),
+								config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s", config.PersistentReceiverRejectedOutcome, config.PersistentReceiverAcceptedOutcome),
 							})
 						},
-						config.PersistentReceiverRejectedOutcome),
+						config.PersistentReceiverRejectedOutcome, shouldAutoAck),
 				) // describe
 			} // for
-
 
 			// Config time fail cases
 
@@ -1617,7 +1616,7 @@ var _ = Describe("PersistentReceiver", func() {
 						config.ReceiverPropertyPersistentMessageRequiredOutcomeSupport: fmt.Sprintf("%s,%s", config.PersistentReceiverFailedOutcome, config.PersistentReceiverRejectedOutcome),
 					})
 				}, config.PersistentReceiverFailedOutcome, true),
-							)
+			)
 
 			Context("with an ACL deny exception", func() {
 				const deniedTopic = "persistent-receiver-acl-deny"

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -301,6 +301,18 @@ var _ = Describe("PersistentReceiver", func() {
 						err := receiver.Ack(nil)
 						helpers.ValidateError(err, &solace.IllegalStateError{})
 					})
+					It("should fail to settle a message as accepted", func() {
+						err := receiver.Settle(nil, config.PersistentReceiverAcceptedOutcome)
+						helpers.ValidateError(err, &solace.IllegalStateError{})
+					})
+					It("should fail to settle a message as failed", func() {
+						err := receiver.Settle(nil, config.PersistentReceiverFailedOutcome)
+						helpers.ValidateError(err, &solace.IllegalStateError{})
+					})
+					It("should fail to settle a message as rejected", func() {
+						err := receiver.Settle(nil, config.PersistentReceiverRejectedOutcome)
+						helpers.ValidateError(err, &solace.IllegalStateError{})
+					})
 					It("should fail to settle a message", func() {
 						err := receiver.Settle(nil, config.PersistentReceiverAcceptedOutcome)
 						helpers.ValidateError(err, &solace.IllegalStateError{})

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -1271,7 +1271,7 @@ var _ = Describe("PersistentReceiver", func() {
 				// ??? I don't speak go, so I'm just rolling with it.
 				autoAck2 := autoAck
 				if autoAck {autoAckText = " withAutoAck"}
-				FDescribeTable("Happy cases for outcome configuration on ReceiverBuilder" + autoAckText,
+				DescribeTable("Happy cases for outcome configuration on ReceiverBuilder" + autoAckText,
 					func(configFunc func(solace.PersistentMessageReceiverBuilder), outcome config.MessageSettlementOutcome) {
 						receiverBuilder := messagingService.CreatePersistentMessageReceiverBuilder()
 						configFunc(receiverBuilder)


### PR DESCRIPTION
**Changes:**
- EBP-52: Implement the receiver builder configuration for message settlement outcome support
- EBP-54: Implement the Settle() method
- EBP-54: fixed doc string format on MessageSettlementOutcome
- EBP-58: added new metrics and response code for Nack
- EBP-58: tracked auto-acks and subtract it from settledAccepted