### PR TITLE
SOL-98116/EBP-43: Memory Allocation Of Error Structs

### DIFF
--- a/internal/ccsmp/ccsmp_container.go
+++ b/internal/ccsmp/ccsmp_container.go
@@ -147,7 +147,7 @@ func (opaqueContainer *SolClientOpaqueContainer) SolClientContainerGetNextField(
 	if errorInfo != nil {
 		// we expect and end of stream, but an error is logged if we fail
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("ccsmp.SolClientContainerGetNextField: Unable to retrieve next field: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("ccsmp.SolClientContainerGetNextField: Unable to retrieve next field: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return "", fieldT, false
 	}
@@ -172,7 +172,7 @@ func (opaqueContainer *SolClientOpaqueContainer) SolClientContainerGetField(key 
 	if errorInfo != nil {
 		// we expect and end of stream, but an error is logged if we fail
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("ccsmp.SolClientContainerGetField: unable to retrieve next field: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("ccsmp.SolClientContainerGetField: unable to retrieve next field: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return fieldT, false
 	}

--- a/internal/ccsmp/ccsmp_core.go
+++ b/internal/ccsmp/ccsmp_core.go
@@ -194,7 +194,7 @@ type SolClientResponseCode = C.solClient_session_responseCode_t
 type SolClientErrorInfoWrapper C.solClient_errorInfo_wrapper_t
 
 // SolClientErrorInfoWrapperDetailed is assigned a value
-type SolClientErrorInfoWrapperDetailed C.solClient_errorInfo_detailed_t
+type SolClientErrorInfoWrapperDetailed C.solClient_errorInfo_t
 
 func (info *SolClientErrorInfoWrapper) String() string {
 	if info == nil {
@@ -206,23 +206,23 @@ func (info *SolClientErrorInfoWrapper) String() string {
 	detailedErrorInfo := *(info.DetailedErrorInfo)
 	return fmt.Sprintf("{ReturnCode: %d, SubCode: %d, ResponseCode: %d, ErrorStr: %s}",
 		info.ReturnCode,
-		detailedErrorInfo.SubCode,
-		detailedErrorInfo.ResponseCode,
+		detailedErrorInfo.subCode,
+		detailedErrorInfo.responseCode,
 		info.GetMessageAsString())
 }
 
 // GetMessageAsString function outputs a string
 func (info *SolClientErrorInfoWrapper) GetMessageAsString() string {
-	if info.DetailedErrorInfo == nil || len(info.DetailedErrorInfo.ErrorStr) == 0 {
+	if info.DetailedErrorInfo == nil || len(info.DetailedErrorInfo.errorStr) == 0 {
 		return ""
 	}
-	return C.GoString((*C.char)(&info.DetailedErrorInfo.ErrorStr[0]))
+	return C.GoString((*C.char)(&info.DetailedErrorInfo.errorStr[0]))
 }
 
 // SubCode function returns subcode if available
 func (info *SolClientErrorInfoWrapper) SubCode() SolClientSubCode {
 	if info.DetailedErrorInfo != nil {
-		return (*(info.DetailedErrorInfo)).SubCode
+		return (*(info.DetailedErrorInfo)).subCode
 	}
 	return SolClientSubCode(0)
 }
@@ -230,7 +230,7 @@ func (info *SolClientErrorInfoWrapper) SubCode() SolClientSubCode {
 // ResponseCode function returns response code if available
 func (info *SolClientErrorInfoWrapper) ResponseCode() SolClientResponseCode {
 	if info.DetailedErrorInfo != nil {
-		return (*(info.DetailedErrorInfo)).ResponseCode
+		return (*(info.DetailedErrorInfo)).responseCode
 	}
 	return SolClientResponseCode(0)
 }
@@ -664,11 +664,11 @@ func GetLastErrorInfoReturnCodeOnly(returnCode SolClientReturnCode) *SolClientEr
 func GetLastErrorInfo(returnCode SolClientReturnCode) *SolClientErrorInfoWrapper {
 	errorInfo := GetLastErrorInfoReturnCodeOnly(returnCode)
 	if returnCode != SolClientReturnCodeNotFound {
-		detailedErrorInfo := C.solClient_errorInfo_detailed_t{}
+		detailedErrorInfo := C.solClient_errorInfo_t{}
 		solClientErrorInfoPt := C.solClient_getLastErrorInfo()
-		detailedErrorInfo.SubCode = solClientErrorInfoPt.subCode
-		detailedErrorInfo.ResponseCode = solClientErrorInfoPt.responseCode
-		C.strcpy((*C.char)(&detailedErrorInfo.ErrorStr[0]), (*C.char)(&solClientErrorInfoPt.errorStr[0]))
+		detailedErrorInfo.subCode = solClientErrorInfoPt.subCode
+		detailedErrorInfo.responseCode = solClientErrorInfoPt.responseCode
+		C.strcpy((*C.char)(&detailedErrorInfo.errorStr[0]), (*C.char)(&solClientErrorInfoPt.errorStr[0]))
 		errorInfo.DetailedErrorInfo = &detailedErrorInfo
 	}
 	return errorInfo

--- a/internal/ccsmp/ccsmp_core.go
+++ b/internal/ccsmp/ccsmp_core.go
@@ -213,7 +213,7 @@ func (info *SolClientErrorInfoWrapper) String() string {
 
 // GetMessageAsString function outputs a string
 func (info *SolClientErrorInfoWrapper) GetMessageAsString() string {
-	if info.DetailedErrorInfo != nil || len(info.DetailedErrorInfo.ErrorStr) == 0 {
+	if info.DetailedErrorInfo == nil || len(info.DetailedErrorInfo.ErrorStr) == 0 {
 		return ""
 	}
 	return C.GoString((*C.char)(&info.DetailedErrorInfo.ErrorStr[0]))

--- a/internal/ccsmp/ccsmp_helper.h
+++ b/internal/ccsmp/ccsmp_helper.h
@@ -20,22 +20,13 @@
 #include "solclient/solClient.h"
 
 // Reexport error info fields as they need to be copied.
-// This struct allows detailed error info to be copied only when it needs to be, saving time and memory.
-typedef struct solClient_errorInfo_detailed
-{ 
-    solClient_subCode_t SubCode;
-    solClient_session_responseCode_t ResponseCode;
-    char ErrorStr[SOLCLIENT_ERRORINFO_STR_SIZE];
-} solClient_errorInfo_detailed_t;
-
-// Reexport error info fields as they need to be copied.
 // Since only a single error info struct will be returned,
 // we add the ReturnCode field. Fields are capitalized to
 // allow them to be exported by the CCSMP package.
 typedef struct solClient_errorInfo_wrapper
 {
     solClient_returnCode_t ReturnCode;
-    solClient_errorInfo_detailed_t * DetailedErrorInfo;
+    solClient_errorInfo_t * DetailedErrorInfo;
 } solClient_errorInfo_wrapper_t;
 
 /**

--- a/internal/ccsmp/ccsmp_helper.h
+++ b/internal/ccsmp/ccsmp_helper.h
@@ -20,15 +20,22 @@
 #include "solclient/solClient.h"
 
 // Reexport error info fields as they need to be copied.
+// This struct allows detailed error info to be copied only when it needs to be, saving time and memory.
+typedef struct solClient_errorInfo_detailed
+{ 
+    solClient_subCode_t SubCode;
+    solClient_session_responseCode_t ResponseCode;
+    char ErrorStr[SOLCLIENT_ERRORINFO_STR_SIZE];
+} solClient_errorInfo_detailed_t;
+
+// Reexport error info fields as they need to be copied.
 // Since only a single error info struct will be returned,
 // we add the ReturnCode field. Fields are capitalized to
 // allow them to be exported by the CCSMP package.
 typedef struct solClient_errorInfo_wrapper
 {
     solClient_returnCode_t ReturnCode;
-    solClient_subCode_t SubCode;
-    solClient_session_responseCode_t ResponseCode;
-    char ErrorStr[SOLCLIENT_ERRORINFO_STR_SIZE];
+    solClient_errorInfo_detailed_t * DetailedErrorInfo;
 } solClient_errorInfo_wrapper_t;
 
 /**

--- a/internal/ccsmp/ccsmp_message.go
+++ b/internal/ccsmp/ccsmp_message.go
@@ -89,9 +89,12 @@ func SolClientMessageGetBinaryAttachmentAsBytes(messageP SolClientMessagePt) ([]
 	})
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
+			return nil, false
+		} else if errorInfo.ReturnCode != SolClientReturnCodeOk {
+			logging.Default.Debug(fmt.Sprintf("Did not find payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
+			return nil, false
 		}
-		return nil, false
 	}
 	return C.GoBytes(dataPtr, C.int(size)), true
 }
@@ -105,9 +108,12 @@ func SolClientMessageGetXMLAttachmentAsBytes(messageP SolClientMessagePt) ([]byt
 	})
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching XML payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching XML payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
+			return nil, false
+		} else if errorInfo.ReturnCode != SolClientReturnCodeOk {
+			logging.Default.Debug(fmt.Sprintf("Did not find XML payload as bytes: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
+			return nil, false
 		}
-		return nil, false
 	}
 	return C.GoBytes(dataPtr, C.int(size)), true
 }
@@ -132,7 +138,7 @@ func SolClientMessageGetBinaryAttachmentAsString(messageP SolClientMessagePt) (s
 	})
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as string: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as string: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return "", false
 	}
@@ -156,7 +162,7 @@ func SolClientMessageGetBinaryAttachmentAsStream(messageP SolClientMessagePt) (*
 	})
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as stream: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as stream: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return nil, false
 	}
@@ -174,7 +180,7 @@ func SolClientMessageGetBinaryAttachmentAsMap(messageP SolClientMessagePt) (*Sol
 	})
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == SolClientReturnCodeFail {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as stream: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching payload as stream: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return nil, false
 	}

--- a/internal/ccsmp/ccsmp_message_tracing.go
+++ b/internal/ccsmp/ccsmp_message_tracing.go
@@ -81,7 +81,7 @@ func SolClientMessageGetTraceContextTraceID(messageP SolClientMessagePt, context
 				fmt.Sprintf(
 					"Encountered error fetching Creation context traceID prop: %s, subcode: %d",
 					errorInfo.GetMessageAsString(),
-					errorInfo.SubCode))
+					errorInfo.SubCode()))
 		}
 		return [TraceIDSize]byte{}, errorInfo
 	}
@@ -122,7 +122,7 @@ func SolClientMessageGetTraceContextSpanID(messageP SolClientMessagePt, contextT
 				fmt.Sprintf(
 					"Encountered error fetching Creation context spanID prop: %s, subcode: %d",
 					errorInfo.GetMessageAsString(),
-					errorInfo.SubCode))
+					errorInfo.SubCode()))
 		}
 		return [SpanIDSize]byte{}, errorInfo
 	}
@@ -161,7 +161,7 @@ func SolClientMessageGetTraceContextSampled(messageP SolClientMessagePt, context
 				fmt.Sprintf(
 					"Encountered error fetching Creation context sampled prop: %s, subcode: %d",
 					errorInfo.GetMessageAsString(),
-					errorInfo.SubCode))
+					errorInfo.SubCode()))
 		}
 		return false, errorInfo
 	}
@@ -198,7 +198,7 @@ func SolClientMessageGetTraceContextTraceState(messageP SolClientMessagePt, cont
 				fmt.Sprintf(
 					"Encountered error fetching Creation contex traceState prop: %s, subcode: %d",
 					errorInfo.GetMessageAsString(),
-					errorInfo.SubCode))
+					errorInfo.SubCode()))
 		}
 		return "", errorInfo
 	}
@@ -336,7 +336,7 @@ func SolClientMessageGetBaggage(messageP SolClientMessagePt) (string, *SolClient
 				fmt.Sprintf(
 					"Encountered error fetching baggage: %s, subcode: %d",
 					errorInfo.GetMessageAsString(),
-					errorInfo.SubCode))
+					errorInfo.SubCode()))
 		}
 		return "", errorInfo
 	}

--- a/internal/ccsmp/cgo_helpers.go
+++ b/internal/ccsmp/cgo_helpers.go
@@ -56,7 +56,7 @@ func ToCArray(arr []string, nullTerminated bool) (cArray **C.char, freeArray fun
 	return (**C.char)(unsafe.Pointer(&cArr[0])), freeFunction
 }
 
-// NewInternalSolClientERrorInfoWrapper manually creates a Go representation of the error struct usually passed to the
+// NewInternalSolClientErrorInfoWrapper manually creates a Go representation of the error struct usually passed to the
 // Go API by CCSMP. This function is intended to be used only when such an error struct is required but cannot be
 // provided by CCSMP.
 func NewInternalSolClientErrorInfoWrapper(returnCode SolClientReturnCode, subCode SolClientSubCode, responseCode SolClientResponseCode, errorInfo string) *SolClientErrorInfoWrapper {

--- a/internal/ccsmp/cgo_helpers.go
+++ b/internal/ccsmp/cgo_helpers.go
@@ -56,7 +56,10 @@ func ToCArray(arr []string, nullTerminated bool) (cArray **C.char, freeArray fun
 	return (**C.char)(unsafe.Pointer(&cArr[0])), freeFunction
 }
 
-func GenerateTestSolClientErrorInfoWrapper(returnCode SolClientReturnCode, subCode SolClientSubCode, responseCode SolClientResponseCode, errorInfo string) *SolClientErrorInfoWrapper {
+// NewInternalSolClientERrorInfoWrapper manually creates a Go representation of the error struct usually passed to the
+// Go API by CCSMP. This function is intended to be used only when such an error struct is required but cannot be
+// provided by CCSMP.
+func NewInternalSolClientErrorInfoWrapper(returnCode SolClientReturnCode, subCode SolClientSubCode, responseCode SolClientResponseCode, errorInfo string) *SolClientErrorInfoWrapper {
 	errorInfoWrapper := SolClientErrorInfoWrapper{}
 	errorInfoWrapper.ReturnCode = returnCode
 	detailedErrorInfo := C.solClient_errorInfo_t{}

--- a/internal/ccsmp/cgo_helpers.go
+++ b/internal/ccsmp/cgo_helpers.go
@@ -59,13 +59,13 @@ func ToCArray(arr []string, nullTerminated bool) (cArray **C.char, freeArray fun
 func GenerateTestSolClientErrorInfoWrapper(returnCode SolClientReturnCode, subCode SolClientSubCode, responseCode SolClientResponseCode, errorInfo string) *SolClientErrorInfoWrapper {
 	errorInfoWrapper := SolClientErrorInfoWrapper{}
 	errorInfoWrapper.ReturnCode = returnCode
-	detailedErrorInfo := C.solClient_errorInfo_detailed_t{}
-	detailedErrorInfo.SubCode = subCode
-	detailedErrorInfo.ResponseCode = responseCode
-	for i := 0; i < len(errorInfo) && i < len(detailedErrorInfo.ErrorStr)-1; i++ {
-		detailedErrorInfo.ErrorStr[i] = (C.char)(errorInfo[i])
+	detailedErrorInfo := C.solClient_errorInfo_t{}
+	detailedErrorInfo.subCode = subCode
+	detailedErrorInfo.responseCode = responseCode
+	for i := 0; i < len(errorInfo) && i < len(detailedErrorInfo.errorStr)-1; i++ {
+		detailedErrorInfo.errorStr[i] = (C.char)(errorInfo[i])
 	}
-	detailedErrorInfo.ErrorStr[len(detailedErrorInfo.ErrorStr)-1] = '\x00'
+	detailedErrorInfo.errorStr[len(detailedErrorInfo.errorStr)-1] = '\x00'
 	errorInfoWrapper.DetailedErrorInfo = &detailedErrorInfo
 	return &errorInfoWrapper
 }

--- a/internal/ccsmp/cgo_helpers.go
+++ b/internal/ccsmp/cgo_helpers.go
@@ -19,6 +19,8 @@ package ccsmp
 /*
 #include <stdio.h>
 #include <stdlib.h>
+
+#include "./ccsmp_helper.h"
 */
 import "C"
 import "unsafe"
@@ -52,4 +54,18 @@ func ToCArray(arr []string, nullTerminated bool) (cArray **C.char, freeArray fun
 		}
 	}
 	return (**C.char)(unsafe.Pointer(&cArr[0])), freeFunction
+}
+
+func GenerateTestSolClientErrorInfoWrapper(returnCode SolClientReturnCode, subCode SolClientSubCode, responseCode SolClientResponseCode, errorInfo string) *SolClientErrorInfoWrapper {
+	errorInfoWrapper := SolClientErrorInfoWrapper{}
+	errorInfoWrapper.ReturnCode = returnCode
+	detailedErrorInfo := C.solClient_errorInfo_detailed_t{}
+	detailedErrorInfo.SubCode = subCode
+	detailedErrorInfo.ResponseCode = responseCode
+	for i := 0; i < len(errorInfo) && i < len(detailedErrorInfo.ErrorStr)-1; i++ {
+		detailedErrorInfo.ErrorStr[i] = (C.char)(errorInfo[i])
+	}
+	detailedErrorInfo.ErrorStr[len(detailedErrorInfo.ErrorStr)-1] = '\x00'
+	errorInfoWrapper.DetailedErrorInfo = &detailedErrorInfo
+	return &errorInfoWrapper
 }

--- a/internal/impl/core/error.go
+++ b/internal/impl/core/error.go
@@ -33,7 +33,7 @@ func ToNativeError(err ErrorInfo, args ...string) error {
 	if len(args) > 0 {
 		prefix = args[0]
 	}
-	nativeError := solace.NewNativeError(prefix+err.GetMessageAsString(), subcode.Code(err.SubCode))
+	nativeError := solace.NewNativeError(prefix+err.GetMessageAsString(), subcode.Code(err.SubCode()))
 	switch nativeError.SubCode() {
 	case subcode.LoginFailure:
 		return solace.NewError(&solace.AuthenticationError{}, constants.LoginFailure+nativeError.Error(), nativeError)

--- a/internal/impl/core/events.go
+++ b/internal/impl/core/events.go
@@ -142,7 +142,7 @@ func (events *ccsmpBackedEvents) eventCallback(sessionEvent ccsmp.SolClientSessi
 			logging.Default.Debug(fmt.Sprintf("Retrieved Last Error Info: %s", lastErrorInfo))
 		}
 		var err error
-		if lastErrorInfo.SubCode != ccsmp.SolClientSubCodeOK {
+		if lastErrorInfo.SubCode() != ccsmp.SolClientSubCodeOK {
 			err = ToNativeError(lastErrorInfo)
 		}
 		for _, eventHandler := range eventHandlers {

--- a/internal/impl/core/receiver.go
+++ b/internal/impl/core/receiver.go
@@ -346,7 +346,7 @@ func (receiver *ccsmpBackedReceiver) NewPersistentReceiver(properties []string, 
 	flowEventCallback := func(flowEvent ccsmp.SolClientFlowEvent, responseCode ccsmp.SolClientResponseCode, info string) {
 		lastErrorInfo := ccsmp.GetLastErrorInfo(0)
 		var err error
-		if lastErrorInfo.SubCode != ccsmp.SolClientSubCodeOK {
+		if lastErrorInfo.SubCode() != ccsmp.SolClientSubCodeOK {
 			err = ToNativeError(lastErrorInfo)
 		}
 		eventCallback(flowEvent, &flowEventInfo{err: err, infoString: info})

--- a/internal/impl/core/transport.go
+++ b/internal/impl/core/transport.go
@@ -151,14 +151,14 @@ func (transport *ccsmpTransport) Close() error {
 func destroySession(session *ccsmp.SolClientSession) {
 	err := session.SolClientSessionDestroy()
 	if err != nil {
-		logging.Default.Error(fmt.Sprintf("an error occurred while cleaning up session: %s (subcode %d)", err.GetMessageAsString(), err.SubCode))
+		logging.Default.Error(fmt.Sprintf("an error occurred while cleaning up session: %s (subcode %d)", err.GetMessageAsString(), err.SubCode()))
 	}
 }
 
 func destroyContext(context *ccsmp.SolClientContext) {
 	err := context.SolClientContextDestroy()
 	if err != nil {
-		logging.Default.Error(fmt.Sprintf("an error occurred while cleaning up context: %s (subcode %d)", err.GetMessageAsString(), err.SubCode))
+		logging.Default.Error(fmt.Sprintf("an error occurred while cleaning up context: %s (subcode %d)", err.GetMessageAsString(), err.SubCode()))
 	}
 }
 

--- a/internal/impl/message/inbound_message_impl.go
+++ b/internal/impl/message/inbound_message_impl.go
@@ -70,7 +70,7 @@ func (message *InboundMessageImpl) Dispose() {
 func freeInboundMessage(message *InboundMessageImpl) {
 	err := ccsmp.SolClientMessageFree(&message.messagePointer)
 	if err != nil && logging.Default.IsErrorEnabled() {
-		logging.Default.Error("encountered unexpected error while freeing message pointer: " + err.GetMessageAsString() + " [sub code = " + strconv.Itoa(int(err.SubCode)) + "]")
+		logging.Default.Error("encountered unexpected error while freeing message pointer: " + err.GetMessageAsString() + " [sub code = " + strconv.Itoa(int(err.SubCode())) + "]")
 	}
 }
 
@@ -81,7 +81,7 @@ func (message *InboundMessageImpl) GetDestinationName() string {
 	destName, errorInfo := ccsmp.SolClientMessageGetDestinationName(message.messagePointer)
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Unable to retrieve the destination this message was published to: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Unable to retrieve the destination this message was published to: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 	}
 	return destName
@@ -94,7 +94,7 @@ func (message *InboundMessageImpl) GetTimeStamp() (time.Time, bool) {
 	t, errInfo := ccsmp.SolClientMessageGetTimestamp(message.messagePointer)
 	if errInfo != nil {
 		if errInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender Timestamp: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender Timestamp: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode()))
 		}
 		return t, false
 	}
@@ -107,7 +107,7 @@ func (message *InboundMessageImpl) GetSenderTimestamp() (time.Time, bool) {
 	t, errInfo := ccsmp.SolClientMessageGetSenderTimestamp(message.messagePointer)
 	if errInfo != nil {
 		if errInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender Timestamp: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender Timestamp: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode()))
 		}
 		return t, false
 	}
@@ -119,7 +119,7 @@ func (message *InboundMessageImpl) GetSenderID() (string, bool) {
 	id, errInfo := ccsmp.SolClientMessageGetSenderID(message.messagePointer)
 	if errInfo != nil {
 		if errInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender ID: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving Sender ID: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode()))
 		}
 		return id, false
 	}
@@ -136,7 +136,7 @@ func (message *InboundMessageImpl) GetReplicationGroupMessageID() (rgmid.Replica
 	rmidPt, errInfo := ccsmp.SolClientMessageGetRGMID(message.messagePointer)
 	if errInfo != nil {
 		if errInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving ReplicationGroupMessageID: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error retrieving ReplicationGroupMessageID: %s, subcode: %d", errInfo.GetMessageAsString(), errInfo.SubCode()))
 		}
 		return nil, false
 	}
@@ -197,7 +197,7 @@ func GetReplyToDestinationName(message *InboundMessageImpl) (string, bool) {
 	destName, errorInfo := ccsmp.SolClientMessageGetReplyToDestinationName(message.messagePointer)
 	if errorInfo != nil {
 		if errorInfo.ReturnCode == ccsmp.SolClientReturnCodeFail {
-			logging.Default.Debug(fmt.Sprintf("Unable to retrieve the reply to destination this message was published to: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Unable to retrieve the reply to destination this message was published to: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return destName, false
 	}

--- a/internal/impl/message/message_impl.go
+++ b/internal/impl/message/message_impl.go
@@ -47,14 +47,14 @@ func (message *MessageImpl) GetProperties() (propMap sdt.Map) {
 	opaqueContainer, errorInfo := ccsmp.SolClientMessageGetUserPropertyMap(message.messagePointer)
 	if errorInfo != nil {
 		if errorInfo.ReturnCode != ccsmp.SolClientReturnCodeNotFound {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching user property map: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching user property map: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return nil
 	}
 	defer func() {
 		errorInfo := opaqueContainer.SolClientContainerClose()
 		if errorInfo != nil && logging.Default.IsDebugEnabled() {
-			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 	}()
 	return parseMap(opaqueContainer)
@@ -67,14 +67,14 @@ func (message *MessageImpl) GetProperty(propertyName string) (propertyValue sdt.
 	opaqueContainer, errorInfo := ccsmp.SolClientMessageGetUserPropertyMap(message.messagePointer)
 	if errorInfo != nil {
 		if errorInfo.ReturnCode != ccsmp.SolClientReturnCodeNotFound {
-			logging.Default.Warning(fmt.Sprintf("Encountered error fetching user property map: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Warning(fmt.Sprintf("Encountered error fetching user property map: %s, subcode: %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 		return nil, false
 	}
 	defer func() {
 		errorInfo := opaqueContainer.SolClientContainerClose()
 		if errorInfo != nil && logging.Default.IsDebugEnabled() {
-			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 	}()
 	val, ok := opaqueContainer.SolClientContainerGetField(propertyName)
@@ -98,6 +98,7 @@ func (message *MessageImpl) HasProperty(propertyName string) bool {
 func (message *MessageImpl) GetPayloadAsBytes() (bytes []byte, ok bool) {
 	binaryAttachmentBytes, binaryAttachmentOk := ccsmp.SolClientMessageGetBinaryAttachmentAsBytes(message.messagePointer)
 	xmlContentBytes, xmlContentOk := ccsmp.SolClientMessageGetXMLAttachmentAsBytes(message.messagePointer)
+	//if binaryAttachmentOk && xmlContentOk && binaryAttachmentBytes == nil && xmlContentBytes == nil {
 	if binaryAttachmentOk && xmlContentOk {
 		logging.Default.Warning(fmt.Sprintf("Internal error: message %p contained multiple payloads", message))
 		return nil, false
@@ -143,7 +144,7 @@ func (message *MessageImpl) GetPayloadAsMap() (sdt.Map, bool) {
 	defer func() {
 		errorInfo := container.SolClientContainerClose()
 		if errorInfo != nil && logging.Default.IsDebugEnabled() {
-			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 	}()
 	parsedMap := parseMap(container)
@@ -165,7 +166,7 @@ func (message *MessageImpl) GetPayloadAsStream() (sdtStream sdt.Stream, ok bool)
 	defer func() {
 		errorInfo := container.SolClientContainerClose()
 		if errorInfo != nil && logging.Default.IsDebugEnabled() {
-			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode))
+			logging.Default.Debug(fmt.Sprintf("Encountered error while closing container: %s, errorCode %d", errorInfo.GetMessageAsString(), errorInfo.SubCode()))
 		}
 	}()
 	parsedStream := parseStream(container)

--- a/internal/impl/message/outbound_message_impl.go
+++ b/internal/impl/message/outbound_message_impl.go
@@ -79,7 +79,7 @@ func (message *OutboundMessageImpl) Dispose() {
 func freeOutboundMessage(message *OutboundMessageImpl) {
 	err := ccsmp.SolClientMessageFree(&message.messagePointer)
 	if err != nil && logging.Default.IsErrorEnabled() {
-		logging.Default.Error("encountered unexpected error while freeing message pointer: " + err.GetMessageAsString() + " [sub code = " + strconv.Itoa(int(err.SubCode)) + "]")
+		logging.Default.Error("encountered unexpected error while freeing message pointer: " + err.GetMessageAsString() + " [sub code = " + strconv.Itoa(int(err.SubCode())) + "]")
 	}
 }
 

--- a/internal/impl/publisher/direct_message_publisher_impl_test.go
+++ b/internal/impl/publisher/direct_message_publisher_impl_test.go
@@ -921,10 +921,10 @@ func TestDirectMessagePublisherPublishFunctionalityDirect(t *testing.T) {
 
 	subCode := 21
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This error info is generated")
 	}
 
 	err = publisher.Publish(testMessage, testTopic)
@@ -1109,10 +1109,10 @@ func TestDirectMessagePublisherTaskFailure(t *testing.T) {
 
 	subCode := 23
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This is a generated error info")
 	}
 
 	testMessage, _ := message.NewOutboundMessage()

--- a/internal/impl/publisher/direct_message_publisher_impl_test.go
+++ b/internal/impl/publisher/direct_message_publisher_impl_test.go
@@ -921,7 +921,7 @@ func TestDirectMessagePublisherPublishFunctionalityDirect(t *testing.T) {
 
 	subCode := 21
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This error info is generated")
@@ -1109,7 +1109,7 @@ func TestDirectMessagePublisherTaskFailure(t *testing.T) {
 
 	subCode := 23
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This is a generated error info")

--- a/internal/impl/publisher/persistent_message_publisher_impl_test.go
+++ b/internal/impl/publisher/persistent_message_publisher_impl_test.go
@@ -1002,7 +1002,7 @@ func TestPersistentMessagePublisherPublishFunctionalityPersistent(t *testing.T) 
 
 	subCode := 21
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This is a generated error info")
@@ -1190,7 +1190,7 @@ func TestPersistentMessagePublisherTaskFailure(t *testing.T) {
 
 	subCode := 23
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This is a generated error info")

--- a/internal/impl/publisher/persistent_message_publisher_impl_test.go
+++ b/internal/impl/publisher/persistent_message_publisher_impl_test.go
@@ -1002,10 +1002,10 @@ func TestPersistentMessagePublisherPublishFunctionalityPersistent(t *testing.T) 
 
 	subCode := 21
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This is a generated error info")
 	}
 
 	err = publisher.Publish(testMessage, testTopic, nil, nil)
@@ -1190,10 +1190,10 @@ func TestPersistentMessagePublisherTaskFailure(t *testing.T) {
 
 	subCode := 23
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This is a generated error info")
 	}
 
 	testMessage, _ := message.NewOutboundMessage()

--- a/internal/impl/publisher/request_reply_message_publisher_impl_test.go
+++ b/internal/impl/publisher/request_reply_message_publisher_impl_test.go
@@ -770,7 +770,7 @@ func TestRequestReplyStartFailedToGetReplyTo(t *testing.T) {
 	internalPublisher.requestor = func() core.Requestor {
 		mock := &mockRequestor{}
 		mock.addRequestorReplyHandler = func(handler core.RequestorReplyHandler) (string, func() (messageID uint64, correlationID string), core.ErrorInfo) {
-			return "", nil, ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			return "", nil, ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 				ccsmp.SolClientSubCode(subCode),
 				ccsmp.SolClientResponseCode(0),
 				"This is a generated error info")
@@ -1424,7 +1424,7 @@ func TestRequestReplyMessagePublisherPublishFunctionalityDirect(t *testing.T) {
 
 	subCode := 21 // ClientDeleteInProgress , note this subcode does not matter just need a subcode that is not OK.
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This is a generated error info")
@@ -1633,7 +1633,7 @@ func TestRequestReplyMessagePublisherTaskFailureReplyOutcome(t *testing.T) {
 
 	subCode := 58 // MissingReplyTo, note this subcode does not matter and does not represent a real scenario
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 			ccsmp.SolClientSubCode(subCode),
 			ccsmp.SolClientResponseCode(0),
 			"This is a generated error info")

--- a/internal/impl/publisher/request_reply_message_publisher_impl_test.go
+++ b/internal/impl/publisher/request_reply_message_publisher_impl_test.go
@@ -770,10 +770,10 @@ func TestRequestReplyStartFailedToGetReplyTo(t *testing.T) {
 	internalPublisher.requestor = func() core.Requestor {
 		mock := &mockRequestor{}
 		mock.addRequestorReplyHandler = func(handler core.RequestorReplyHandler) (string, func() (messageID uint64, correlationID string), core.ErrorInfo) {
-			return "", nil, &ccsmp.SolClientErrorInfoWrapper{
-				ReturnCode: ccsmp.SolClientReturnCodeFail,
-				SubCode:    ccsmp.SolClientSubCode(subCode),
-			}
+			return "", nil, ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+				ccsmp.SolClientSubCode(subCode),
+				ccsmp.SolClientResponseCode(0),
+				"This is a generated error info")
 		}
 		return mock
 	}
@@ -1424,10 +1424,10 @@ func TestRequestReplyMessagePublisherPublishFunctionalityDirect(t *testing.T) {
 
 	subCode := 21 // ClientDeleteInProgress , note this subcode does not matter just need a subcode that is not OK.
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This is a generated error info")
 	}
 
 	err = publisher.Publish(testMessage, testReplyHandler, testTopic, testTimeout, nil /*properties*/, nil /*usercontext*/)
@@ -1633,10 +1633,10 @@ func TestRequestReplyMessagePublisherTaskFailureReplyOutcome(t *testing.T) {
 
 	subCode := 58 // MissingReplyTo, note this subcode does not matter and does not represent a real scenario
 	internalPublisher.publish = func(message ccsmp.SolClientMessagePt) core.ErrorInfo {
-		return &ccsmp.SolClientErrorInfoWrapper{
-			ReturnCode: ccsmp.SolClientReturnCodeFail,
-			SubCode:    ccsmp.SolClientSubCode(subCode),
-		}
+		return ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+			ccsmp.SolClientSubCode(subCode),
+			ccsmp.SolClientResponseCode(0),
+			"This is a generated error info")
 	}
 
 	testMessage, _ := message.NewOutboundMessage()

--- a/internal/impl/receiver/direct_message_receiver_impl_test.go
+++ b/internal/impl/receiver/direct_message_receiver_impl_test.go
@@ -498,9 +498,11 @@ func TestDirectReceiverSubscribeWithError(t *testing.T) {
 	}
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
-	solClientErr := &ccsmp.SolClientErrorInfoWrapper{
-		SubCode: 123,
-	}
+	subCode := 123
+	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error info")
 	for _, fn := range subscriptionFunctions {
 		receiver.subscriptions = []string{}
 		internalReceiverCalled := false
@@ -642,9 +644,11 @@ func TestDirectReceiverUnsubscribeWithError(t *testing.T) {
 	}
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
-	solClientErr := &ccsmp.SolClientErrorInfoWrapper{
-		SubCode: 123,
-	}
+	subCode := 123
+	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error info")
 	for _, fn := range unsubscriptionFunctions {
 		receiver.subscriptions = []string{topic}
 		internalReceiverCalled := false

--- a/internal/impl/receiver/direct_message_receiver_impl_test.go
+++ b/internal/impl/receiver/direct_message_receiver_impl_test.go
@@ -499,7 +499,7 @@ func TestDirectReceiverSubscribeWithError(t *testing.T) {
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
 	subCode := 123
-	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+	solClientErr := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"This is a generated error info")
@@ -645,7 +645,7 @@ func TestDirectReceiverUnsubscribeWithError(t *testing.T) {
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
 	subCode := 123
-	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+	solClientErr := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"This is a generated error info")

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -275,7 +275,7 @@ func (receiver *persistentMessageReceiverImpl) provisionEndpoint() error {
 	if receiver.doCreateMissingResources && receiver.queue.IsDurable() {
 		errInfo := receiver.internalReceiver.ProvisionEndpoint(receiver.queue.GetName(), receiver.queue.IsExclusivelyAccessible())
 		if errInfo != nil {
-			if subcode.Code(errInfo.SubCode) == subcode.EndpointAlreadyExists {
+			if subcode.Code(errInfo.SubCode()) == subcode.EndpointAlreadyExists {
 				receiver.logger.Info("Endpoint '" + receiver.queue.GetName() + "' already exists")
 			} else {
 				receiver.logger.Warning("Failed to provision endpoint '" + receiver.queue.GetName() + "', " + errInfo.GetMessageAsString())
@@ -1128,7 +1128,7 @@ func (receiver *persistentMessageReceiverImpl) run() {
 					} else {
 						errInfo := receiver.internalFlow.Ack(msgID)
 						if errInfo != nil {
-							receiver.logger.Warning("Failed to acknowledge message: " + errInfo.GetMessageAsString() + ", sub code: " + fmt.Sprint(errInfo.SubCode))
+							receiver.logger.Warning("Failed to acknowledge message: " + errInfo.GetMessageAsString() + ", sub code: " + fmt.Sprint(errInfo.SubCode()))
 						}
 					}
 				}

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -412,7 +412,7 @@ func TestPersistentReceiverSubscribeWithError(t *testing.T) {
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
 	subCode := 123
-	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+	solClientErr := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"This is a generated error ErrorInfo")
@@ -563,7 +563,7 @@ func TestPersistentReceiverUnsubscribeWithError(t *testing.T) {
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
 	subCode := 123
-	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+	solClientErr := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"This is a generated error info")

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -411,9 +411,11 @@ func TestPersistentReceiverSubscribeWithError(t *testing.T) {
 	}
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
-	solClientErr := &ccsmp.SolClientErrorInfoWrapper{
-		SubCode: 123,
-	}
+	subCode := 123
+	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error ErrorInfo")
 	for _, fn := range subscriptionFunctions {
 		receiver.subscriptions = []string{}
 		internalReceiverCalled := false
@@ -560,9 +562,11 @@ func TestPersistentReceiverUnsubscribeWithError(t *testing.T) {
 	}
 	topic := "some topic"
 	subscription := resource.TopicSubscriptionOf(topic)
-	solClientErr := &ccsmp.SolClientErrorInfoWrapper{
-		SubCode: 123,
-	}
+	subCode := 123
+	solClientErr := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCode(0),
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error info")
 	for _, fn := range unsubscriptionFunctions {
 		receiver.subscriptions = []string{topic}
 		internalReceiverCalled := false

--- a/internal/impl/receiver/request_reply_message_receiver_impl_test.go
+++ b/internal/impl/receiver/request_reply_message_receiver_impl_test.go
@@ -59,7 +59,7 @@ func TestReplierFailedSendReply(t *testing.T) {
 	replyErrInfo := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
-		"This is a generated error ErrorInfo")
+		"")
 
 	internalReplier.sendReply = func(replyMsg core.ReplyPublishable) core.ErrorInfo {
 		return replyErrInfo

--- a/internal/impl/receiver/request_reply_message_receiver_impl_test.go
+++ b/internal/impl/receiver/request_reply_message_receiver_impl_test.go
@@ -56,10 +56,10 @@ func TestReplierFailedSendReply(t *testing.T) {
 	replier := &replierImpl{}
 	internalReplier := &mockReplier{}
 
-	replyErrInfo := &ccsmp.SolClientErrorInfoWrapper{
-		ReturnCode: ccsmp.SolClientReturnCodeFail,
-		SubCode:    ccsmp.SolClientSubCode(subCode),
-	}
+	replyErrInfo := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error ErrorInfo")
 
 	internalReplier.sendReply = func(replyMsg core.ReplyPublishable) core.ErrorInfo {
 		return replyErrInfo
@@ -84,11 +84,10 @@ func TestReplierWouldBlockSendReply(t *testing.T) {
 	replier := &replierImpl{}
 	internalReplier := &mockReplier{}
 
-	replyErrInfo := &ccsmp.SolClientErrorInfoWrapper{
-		ReturnCode: ccsmp.SolClientReturnCodeWouldBlock,
-		SubCode:    ccsmp.SolClientSubCode(subCode),
-	}
-
+	replyErrInfo := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeWouldBlock,
+		ccsmp.SolClientSubCode(subCode),
+		ccsmp.SolClientResponseCode(0),
+		"This is a generated error info.")
 	internalReplier.sendReply = func(replyMsg core.ReplyPublishable) core.ErrorInfo {
 		return replyErrInfo
 	}

--- a/internal/impl/receiver/request_reply_message_receiver_impl_test.go
+++ b/internal/impl/receiver/request_reply_message_receiver_impl_test.go
@@ -56,7 +56,7 @@ func TestReplierFailedSendReply(t *testing.T) {
 	replier := &replierImpl{}
 	internalReplier := &mockReplier{}
 
-	replyErrInfo := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
+	replyErrInfo := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail,
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"")
@@ -84,7 +84,7 @@ func TestReplierWouldBlockSendReply(t *testing.T) {
 	replier := &replierImpl{}
 	internalReplier := &mockReplier{}
 
-	replyErrInfo := ccsmp.GenerateTestSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeWouldBlock,
+	replyErrInfo := ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeWouldBlock,
 		ccsmp.SolClientSubCode(subCode),
 		ccsmp.SolClientResponseCode(0),
 		"This is a generated error info.")


### PR DESCRIPTION
Changed internal error struct used for GetLastErrorInfo so that it only allocates a char array when necessary. Adapted unit tests and helpers to new error struct, mostly around construction. The purpose of this change was to make the memory allocation of error structs within the API more efficient.