### PR TITLE
EBP-46: pinned the go version for the linux musl node to 1.22.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,11 +39,15 @@ builder.goapi([
   "validationGoVer": 'auto-v1.17.x',
   "getTestPermutations": {
     List<List<String>> permutations = []
-    for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.LINUX_MUSL, builder.DARWIN_X86_64,  builder.DARWIN_ARM]) {
+    for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.DARWIN_X86_64,  builder.DARWIN_ARM]) {
       for (gover in ['auto-latest', 'auto-previous']) {
         permutations << [platform, gover]
       }
     }
+    // run tests on the last stable Go version (1.22.4) for linux musl
+    // See EBP-46
+    // and this issue here - https://go-review.googlesource.com/c/go/+/600296
+    permissions << [builder.LINUX_MUSL, 'auto-v1.22.4']
     return permutations
   }
 ]) 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ builder.goapi([
     // run tests on the last stable Go version (1.22.4) for linux musl
     // See EBP-46
     // and this issue here - https://go-review.googlesource.com/c/go/+/600296
-    permissions << [builder.LINUX_MUSL, 'auto-v1.22.4']
+    permutations << [builder.LINUX_MUSL, 'auto-v1.22.4']
     return permutations
   }
 ]) 

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -621,11 +621,7 @@ var _ = Describe("PersistentReceiver", func() {
 					Eventually(msgChan).Should(Receive(Not(BeNil())))
 				})
 
-				Context("pause and resume tests", Label("flaky-tests"), func() {
-					BeforeEach(func() {
-						Skip("Currently failing in Jenkins pipeline on Linux Musl nodes - SOL-124616")
-					})
-
+				Context("pause and resume tests", func() {
 					It("can pause and resume messaging repeatedly", func() {
 						numMessages := 1000
 						msgChan := make(chan message.InboundMessage, numMessages)
@@ -811,11 +807,9 @@ var _ = Describe("PersistentReceiver", func() {
 				})
 			})
 
-			const numQueuedMessages = 10000
-			Context(fmt.Sprintf("with %d queued messages", numQueuedMessages), Label("flaky-tests"), func() {
+			const numQueuedMessages = 5000
+			Context(fmt.Sprintf("with %d queued messages", numQueuedMessages), func() {
 				BeforeEach(func() {
-					Skip("Currently failing in Jenkins pipeline on Linux Musl nodes - SOL-124616")
-
 					helpers.PublishNPersistentMessages(messagingService, topicString, numQueuedMessages)
 					Eventually(func() int {
 						resp, _, err := testcontext.SEMP().Monitor().QueueApi.GetMsgVpnQueueMsgs(testcontext.SEMP().MonitorCtx(),


### PR DESCRIPTION
**Changes:**
- pinned the go version for the linux musl node to 1.22.4