### PR TITLE
EBP-16: As a developer, I can instantiate a cache request configuration for all variations

### DIFF
--- a/internal/ccsmp/ccsmp_cache.go
+++ b/internal/ccsmp/ccsmp_cache.go
@@ -1,0 +1,38 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ccsmp
+
+/*
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <string.h>
+
+#include "solclient/solClient.h"
+#include "solclient/solClientMsg.h"
+#include "solclient/solCache.h"
+*/
+import "C"
+import "solace.dev/go/messaging/pkg/solace/cache"
+
+// Mapping for Cached message Subscription Request Strategies to respectiveCCSMP flags
+var cachedMessageSubscriptionRequestStrategyMappingToCCSMP = map[cache.CachedMessageSubscriptionStrategy]C.solClient_cacheRequestFlags_t{
+	cache.AsAvailable:       C.SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_FLOWTHRU | C.SOLCLIENT_CACHEREQUEST_FLAGS_NOWAIT_REPLY,
+	cache.LiveCancelsCached: C.SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_FULFILL | C.SOLCLIENT_CACHEREQUEST_FLAGS_NOWAIT_REPLY,
+	cache.CachedFirst:       C.SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_QUEUE | C.SOLCLIENT_CACHEREQUEST_FLAGS_NOWAIT_REPLY,
+	cache.CachedOnly:        C.SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_FLOWTHRU | C.SOLCLIENT_CACHEREQUEST_FLAGS_NOWAIT_REPLY,
+}

--- a/internal/impl/cache/receiver_cache_request_impl.go
+++ b/internal/impl/cache/receiver_cache_request_impl.go
@@ -47,6 +47,30 @@ func (request *cachedMessageSubscriptionRequest) GetName() string {
 	return request.name
 }
 
+// cacheResponse provides information about the response received from the cache.
+type cacheResponse struct {
+	cacheRequestOutcome cache.CacheRequestOutcome
+	cacheRequestID      message.CacheRequestID
+	err                 error
+}
+
+// GetCacheRequestOutcome describes at a high level the result of the cache request.
+func (response *cacheResponse) GetCacheRequestOutcome() cache.CacheRequestOutcome {
+	return response.cacheRequestOutcome
+}
+
+// GetCacheRequestID provides a unique integer that can be used
+// to correlate cache responses and the received, previously cached data messages.
+func (response *cacheResponse) GetCacheRequestID() message.CacheRequestID {
+	return response.cacheRequestID
+}
+
+// GetError the error field will be nil if the cache request was successful,
+// and will be not nil if a problem was encountered.
+func (response *cacheResponse) GetError() error {
+	return response.err
+}
+
 // receiverCacheRequestImpl structure
 type receiverCacheRequestImpl struct {
 	logger logging.LogLevelLogger
@@ -83,8 +107,6 @@ func (receiverCacheRequest *receiverCacheRequestImpl) NewCachedMessageSubscripti
 	cacheAccessTimeout int32,
 	maxCachedMessages int32,
 	cachedMessageAge int32) (cache.CachedMessageSubscriptionRequest, error) {
-	// Todo: Implementation here
-	// do some validations here
 	// validate the cachedMessageSubscriptionStrategy
 	switch cachedMessageSubscriptionStrategy {
 	case cache.AsAvailable:

--- a/internal/impl/cache/receiver_cache_request_impl.go
+++ b/internal/impl/cache/receiver_cache_request_impl.go
@@ -1,0 +1,139 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resource contains types and factory functions for various
+// broker resources such as topics and queues.
+package cache
+
+import (
+	"fmt"
+	"math"
+
+	"solace.dev/go/messaging/internal/impl/logging"
+	"solace.dev/go/messaging/internal/impl/validation"
+	"solace.dev/go/messaging/pkg/solace"
+	"solace.dev/go/messaging/pkg/solace/cache"
+	"solace.dev/go/messaging/pkg/solace/message"
+	"solace.dev/go/messaging/pkg/solace/resource"
+)
+
+type cachedMessageSubscriptionRequest struct {
+	cacheName          string
+	name               string
+	subscription       resource.TopicSubscription
+	cacheAccessTimeout int32
+	maxCachedMessages  int32
+	cachedMessageAge   int32
+}
+
+// GetCacheName retrieves the name of the cache.
+func (request *cachedMessageSubscriptionRequest) GetCacheName() string {
+	return request.cacheName
+}
+
+// GetName retrieves the name of the topic subscription.
+func (request *cachedMessageSubscriptionRequest) GetName() string {
+	return request.name
+}
+
+// receiverCacheRequestImpl structure
+type receiverCacheRequestImpl struct {
+	logger logging.LogLevelLogger
+}
+
+// NewReceiverCacheRequestImpl function
+func NewReceiverCacheRequestImpl() solace.ReceiverCacheRequest {
+	return &receiverCacheRequestImpl{
+		logger: logging.For(receiverCacheRequestImpl{}),
+	}
+}
+
+// NewCachedMessageSubscriptionRequest returns a CachedMessageSubscriptionRequest that can be used to configure a cache request
+// and an error indicating whether or not the operation was successful. If the operation was successful the error is nil. Otherwise,
+// the error will be non-nil and will indicate the reason the operation failed.
+// The cachedMessageSubscriptionStrategy indicates how the API should pass received cached/live messages to the API after a cache
+// request has been sent. Refer to [CachedMessageSubscriptionStrategy] for details on what behaviour each strategy configures.
+// The cache_name parameter indicates the name of the cache to retrieve messages from.
+// The subscription parameter indicates what topic the cache request should match against
+// The cacheAccessTimeout parameter indicates how long in milliseconds a cache request is permitted to take before it is internally
+// cancelled. The valid range for this timeout is between 3000 and signed int 32 max. This value specifies a timer for the internal
+// requests that occur between this API and a PubSub+ cache. A single call to a [ReceiverCacheRequests] interface method
+// can lead to one or more of these internal requests. As long as each of these internal requests
+// complete before the specified time-out, the timeout value is satisfied.
+// The maxCachedMessages parameter indicates the max number of messages expected to be returned as a part of a cache response. The range
+// of this paramater is between 0 and signed int32 max, with 0 indicating that there should be no restrictions on the number of messages
+// received as a part of a cache request.
+// The cachedMessageAge parameter indicates the max age in seconds of the messages to be retrieved from a cache. The range
+// of this parameter is between 0 and signed int 32 max, with 0 indicating that there should be no restrictions on the age of messages
+// to be retrieved.
+func (receiverCacheRequest *receiverCacheRequestImpl) NewCachedMessageSubscriptionRequest(cachedMessageSubscriptionStrategy cache.CachedMessageSubscriptionStrategy,
+	cacheName string,
+	subscription resource.TopicSubscription,
+	cacheAccessTimeout int32,
+	maxCachedMessages int32,
+	cachedMessageAge int32) (cache.CachedMessageSubscriptionRequest, error) {
+	// Todo: Implementation here
+	// do some validations here
+	// validate for the cacheName Timeout range
+	_, _, err := validation.StringPropertyValidation("cacheName", cacheAccessTimeout)
+	if err != nil {
+		return nil, err
+	}
+	if (subscription == resource.TopicSubscription{}) {
+		return nil, solace.NewError(&solace.InvalidConfigurationError{}, fmt.Sprintf("expected required property 'subscription' to be set"), nil)
+	}
+	// validate for the cacheAccess Timeout range
+	_, _, err = validation.IntegerPropertyValidationWithRange("cacheAccessTimeout", cacheAccessTimeout, 3000, math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+	// validate for the cache messages range
+	_, _, err = validation.IntegerPropertyValidationWithRange("maxCachedMessages", cacheAccessTimeout, 0, math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+	// validate for the cache message TTL range
+	_, _, err = validation.IntegerPropertyValidationWithRange("cachedMessageAge", cachedMessageAge, 0, math.MaxInt32)
+	if err != nil {
+		return nil, err
+	}
+
+	// return back a valid cache message subscription request if everything checks out
+	return &cachedMessageSubscriptionRequest{
+		name:               cacheName,
+		cacheName:          cacheName,
+		subscription:       subscription,
+		cacheAccessTimeout: cacheAccessTimeout,
+		maxCachedMessages:  maxCachedMessages,
+		cachedMessageAge:   cachedMessageAge,
+	}, nil
+}
+
+// RequestCachedAsync asynchronously requests cached data from a cache, and
+// defers processing of the resulting cache response to the application through
+// the returned channel.
+func (receiverCacheRequest *receiverCacheRequestImpl) RequestCachedAsync(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
+	cacheRequestId message.CacheRequestID) <-chan cache.CacheResponse {
+	// TODO: Implementation here
+	return nil
+}
+
+// RequestCachedAsyncWithCallback asynchronously requests cached data from a cache,
+// and processes the resulting cache response through the provided function callback.
+func (receiverCacheRequest *receiverCacheRequestImpl) RequestCachedAsyncWithCallback(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
+	cacheRequestId message.CacheRequestID, callback func(cache.CacheResponse)) {
+	// TODO: Implementation here
+}

--- a/internal/impl/cache/receiver_cache_request_impl_test.go
+++ b/internal/impl/cache/receiver_cache_request_impl_test.go
@@ -1,0 +1,249 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"math"
+	"testing"
+
+	"solace.dev/go/messaging/pkg/solace/cache"
+	"solace.dev/go/messaging/pkg/solace/resource"
+)
+
+func TestNewCachedMessageSubscriptionRequestWithInvalidPositiveCachedMessageSubscriptionStrategy(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const invalidCachedMessageSubscriptionStrategy = 5 // invalid subscription strategy
+	const cacheAccessTimeout = 3001                    // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5                        // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15                        // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(invalidCachedMessageSubscriptionStrategy,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with invalid cachedMessageSubscriptionStrategy (5)")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithInvalidNegativeCachedMessageSubscriptionStrategy(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const invalidCachedMessageSubscriptionStrategy = -1 // invalid subscription strategy
+	const cacheAccessTimeout = 3001                     // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5                         // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15                         // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(invalidCachedMessageSubscriptionStrategy,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with invalid cachedMessageSubscriptionStrategy (-1)")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidCachedMessageSubscriptionStrategy(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 3001 // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.LiveCancelsCached,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid cachedMessageSubscriptionStrategy. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithEmptyCacheName(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "" // empty cache name not valid
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000 // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with empty cacheName")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithNilSubscription(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const cacheAccessTimeout = 5000 // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, nil, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with nil topic subscription")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithInvalidCacheAccessTimeout(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 2999 // less than the allowed cache access time (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with out of range cacheAccessTimeout")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidLowerLimitOfCacheAccessTimeout(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 3000 // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid lower limit of cacheAccessTimeout. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidUpperLimitOfCacheAccessTimeout(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = math.MaxInt32 // greater than the allowed cache access time (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 5              // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15              // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid upper limit of cacheAccessTimeout. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithInvalidMaxCachedMessages(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000 // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = -1    // invalid value (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with out of range maxCachedMessages")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidLowerLimitOfMaxCachedMessages(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000 // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 0     // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15     // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid lower limit of maxCachedMessages. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidUpperLimitOfMaxCachedMessages(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000         // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = math.MaxInt32 // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 15             // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid upper limit of maxCachedMessages. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithInvalidCachedMessageAge(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000 // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 50    // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = -1     // invalid value (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest != nil || err == nil {
+		t.Error("Expected error while calling NewCachedMessageSubscriptionRequest() with out of range cachedMessageAge")
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidLowerLimitOfCachedMessageAge(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000 // in valid range - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 50    // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = 0      // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid lower limit of cachedMessageAge. Error: ", err)
+	}
+}
+
+func TestNewCachedMessageSubscriptionRequestWithValidUpperLimitOfCachedMessageAge(t *testing.T) {
+	cacheRequest := NewReceiverCacheRequestImpl()
+	const cacheName = "test-cache"
+	const subscriptionString = "some-subscription"
+	subscription := resource.TopicSubscriptionOf(subscriptionString)
+	const cacheAccessTimeout = 5000        // (in milliseconds) - (valid range from 3000 to signed MaxInt32)
+	const maxCachedMessages = 50           // in valid range (valid range from 0 to signed MaxInt32)
+	const cachedMessageAge = math.MaxInt32 // in valid range (valid range from 0 to signed MaxInt32)
+	cachedMessageSubscriptionRequest, err := cacheRequest.NewCachedMessageSubscriptionRequest(cache.AsAvailable,
+		cacheName, subscription, cacheAccessTimeout, maxCachedMessages, cachedMessageAge)
+
+	if cachedMessageSubscriptionRequest == nil || err != nil {
+		t.Error("Did not expect error while calling NewCachedMessageSubscriptionRequest() with valid upper limit of cachedMessageAge. Error: ", err)
+	}
+}

--- a/internal/impl/messaging_service_impl.go
+++ b/internal/impl/messaging_service_impl.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"solace.dev/go/messaging/internal/impl/cache"
 	"solace.dev/go/messaging/internal/impl/executor"
 	"solace.dev/go/messaging/internal/impl/future"
 	"solace.dev/go/messaging/internal/impl/receiver"
@@ -325,7 +326,9 @@ func (service *messagingServiceImpl) MessageBuilder() solace.OutboundMessageBuil
 
 // EndpointProvisioner aids the type-safe collection of queue properties,
 // and can provision multiple queues with different names (but identical properties) on the broker.
-// Warning: This is a mutable object. The fluent builder style setters modify and return the original object. Make copies explicitly.
+// Warning: This is a mutable object.
+// The fluent builder style setters modify and return the original object.
+// Make copies explicitly.
 func (service *messagingServiceImpl) EndpointProvisioner() solace.EndpointProvisioner {
 	return provisioner.NewEndpointProvisionerImpl(service.transport.EndpointProvisioner())
 }
@@ -499,6 +502,12 @@ func (service *messagingServiceImpl) RequestReply() solace.RequestReplyMessaging
 	return &requestReplyServiceImpl{
 		messagingService: service,
 	}
+}
+
+// ReceiverCacheRequest is used to create and manage cache requests and inherits
+// the configuration of this MessagingService instance.
+func (service *messagingServiceImpl) ReceiverCacheRequest() solace.ReceiverCacheRequest {
+	return cache.NewReceiverCacheRequestImpl()
 }
 
 func (service *messagingServiceImpl) String() string {

--- a/internal/impl/provisioner/endpoint_provisioner_impl.go
+++ b/internal/impl/provisioner/endpoint_provisioner_impl.go
@@ -295,10 +295,8 @@ func (provisioner *endpointProvisionerImpl) Deprovision(queueName string, ignore
 		return solace.NewError(&solace.IllegalStateError{}, constants.UnableToDeprovisionParentServiceNotStarted, nil)
 	}
 
-	properties := provisioner.properties.GetConfiguration() // we don't need all these properties for deprov
-
-	// Override defaults durability to be True since we currently only support durable
-	// properties[config.EndpointPropertyDurable] = true
+	// we don't need all these properties for deprov
+	properties := provisioner.properties.GetConfiguration()
 
 	endpointProperties, err := validateEndpointProperties(properties)
 	if err != nil {

--- a/pkg/solace/cache/cache_request_outcome.go
+++ b/pkg/solace/cache/cache_request_outcome.go
@@ -1,0 +1,77 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache contains the interfaces required by the cache feature.
+package cache
+
+import "solace.dev/go/messaging/pkg/solace/message"
+
+// CacheResponse provides information about the response received from the cache.
+type CacheResponse interface {
+	// GetCacheRequestOutcome describes at a high level the result of the cache request.
+	GetCacheRequestOutcome() CacheRequestOutcome
+
+	// GetCacheRequestID provides a unique integer that can be used
+	// to correlate cache responses and the received, previously cached data messages.
+	GetCacheRequestID() message.CacheRequestID
+
+	// GetError - the error field will be nil if the cache request was successful
+	GetError() error
+}
+
+// cacheResponse provides information about the response received from the cache.
+type cacheResponse struct {
+	cacheRequestOutcome CacheRequestOutcome
+	cacheRequestID      message.CacheRequestID
+	err                 error
+}
+
+// Refer to the [CacheRequestOutcome] for details on what this field indicates.
+func (c *cacheResponse) GetCacheRequestOutcome() CacheRequestOutcome {
+	return c.cacheRequestOutcome
+}
+
+// GetCacheRequestId refer to [CacheRequestID] for details on what this field indicates
+func (c *cacheResponse) GetCacheRequestID() message.CacheRequestID {
+	return c.cacheRequestID
+}
+
+// GetError the error field will be nil if the cache request was successful,
+// and will be not nil if a problem was encountered.
+func (c *cacheResponse) GetError() error {
+	return c.err
+}
+
+// CacheRequestOutcome represents the outcome of a cache response.
+// Refer to the doc string of each variant for more details.
+type CacheRequestOutcome int
+
+const (
+	// Ok indicates that the cache request succeeded, and returned cached messages
+	Ok CacheRequestOutcome = iota
+
+	// NoData indicates that the cache request succeeded,
+	// but that no cached messages were available to be returned
+	NoData
+
+	// SuspectData indicates that the cache request succeeded,
+	// but that the returned cached messages came from a suspect cache.
+	SuspectData
+
+	// Failed indicates that the cache request failed in some way.
+	// Refer to the 'error' associated with this outcome through the RequestCached interface.
+	Failed
+)

--- a/pkg/solace/cache/cache_request_outcome.go
+++ b/pkg/solace/cache/cache_request_outcome.go
@@ -32,30 +32,6 @@ type CacheResponse interface {
 	GetError() error
 }
 
-// cacheResponse provides information about the response received from the cache.
-type cacheResponse struct {
-	cacheRequestOutcome CacheRequestOutcome
-	cacheRequestID      message.CacheRequestID
-	err                 error
-}
-
-// GetCacheRequestOutcome describes at a high level the result of the cache request.
-func (c *cacheResponse) GetCacheRequestOutcome() CacheRequestOutcome {
-	return c.cacheRequestOutcome
-}
-
-// GetCacheRequestID provides a unique integer that can be used
-// to correlate cache responses and the received, previously cached data messages.
-func (c *cacheResponse) GetCacheRequestID() message.CacheRequestID {
-	return c.cacheRequestID
-}
-
-// GetError the error field will be nil if the cache request was successful,
-// and will be not nil if a problem was encountered.
-func (c *cacheResponse) GetError() error {
-	return c.err
-}
-
 // CacheRequestOutcome represents the outcome of a cache response.
 // Refer to the doc string of each variant for more details.
 type CacheRequestOutcome int

--- a/pkg/solace/cache/cache_request_outcome.go
+++ b/pkg/solace/cache/cache_request_outcome.go
@@ -39,12 +39,13 @@ type cacheResponse struct {
 	err                 error
 }
 
-// Refer to the [CacheRequestOutcome] for details on what this field indicates.
+// GetCacheRequestOutcome describes at a high level the result of the cache request.
 func (c *cacheResponse) GetCacheRequestOutcome() CacheRequestOutcome {
 	return c.cacheRequestOutcome
 }
 
-// GetCacheRequestId refer to [CacheRequestID] for details on what this field indicates
+// GetCacheRequestID provides a unique integer that can be used
+// to correlate cache responses and the received, previously cached data messages.
 func (c *cacheResponse) GetCacheRequestID() message.CacheRequestID {
 	return c.cacheRequestID
 }

--- a/pkg/solace/cache/cached_message_subscription_request.go
+++ b/pkg/solace/cache/cached_message_subscription_request.go
@@ -1,0 +1,51 @@
+// pubsubplus-go-client
+//
+// Copyright 2021-2024 Solace Corporation. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache contains the interfaces required by the cache feature.
+package cache
+
+// CachedMessageSubscriptionRequest provides an interface through which cache request configurations can be constructed. These
+// configurations can then be passed to a call to a [RequestCached] interface method to request cached data. Refer to each of the below
+// factory methods for details on what configuration they provide.
+type CachedMessageSubscriptionRequest interface {
+	// GetCacheName retrieves the name of the cache.
+	GetCacheName() string
+
+	// GetName retrieves the name of the topic subscription.
+	GetName() string
+}
+
+// CachedMessageSubscriptionStrategy indicates how the API should pass received cached and live messages to the application. Refer to each
+// variant for details on what behaviour they configure.
+type CachedMessageSubscriptionStrategy int
+
+const (
+	// AsAvailable provides a configuration for receiving a concurrent mix of both live and cached messages on the given TopicSubscription.
+	AsAvailable CachedMessageSubscriptionStrategy = iota
+
+	// LiveCancelsCached provides a configuration for initially passing received cached messages to the application and as soon as live
+	// messages are received, passing those instead and passing no more cached messages.
+	LiveCancelsCached
+
+	// CachedFirst provides a configuration for passing only cached messages to the application, before passing the received live messages.
+	// The live messages passed to the application thereof this configuration can be received as early as when the cache request is sent
+	// by the API, and are enqueued until the cache response is received and its associated cached messages, if available, are passed to
+	// the application.
+	CachedFirst
+
+	// CachedOnly provides a configuration for passing only cached messages and no live messages to the application.
+	CachedOnly
+)

--- a/pkg/solace/message/inbound_message.go
+++ b/pkg/solace/message/inbound_message.go
@@ -22,6 +22,10 @@ import (
 	"solace.dev/go/messaging/pkg/solace/message/rgmid"
 )
 
+// A type to be used for correlating received,
+// previously cached messages with their associated cache response.
+type CacheRequestID uint64
+
 // InboundMessage represents a message received by a consumer.
 type InboundMessage interface {
 	// Extend the Message interface.

--- a/pkg/solace/message/inbound_message.go
+++ b/pkg/solace/message/inbound_message.go
@@ -22,7 +22,7 @@ import (
 	"solace.dev/go/messaging/pkg/solace/message/rgmid"
 )
 
-// A type to be used for correlating received,
+// CacheRequestID - a type to be used for correlating received,
 // previously cached messages with their associated cache response.
 type CacheRequestID uint64
 

--- a/pkg/solace/messaging_service.go
+++ b/pkg/solace/messaging_service.go
@@ -72,6 +72,10 @@ type MessagingService interface {
 	// the configuration of this MessagingService instance.
 	RequestReply() RequestReplyMessagingService
 
+	// ReceiverCacheRequest is used to create and manage cache requests and inherits
+	// the configuration of this MessagingService instance.
+	ReceiverCacheRequest() ReceiverCacheRequest
+
 	// Disconnect disconnects the messaging service.
 	// The messaging service must be connected to disconnect.
 	// This function blocks until the disconnection attempt is completed.

--- a/pkg/solace/receiver_cache_request.go
+++ b/pkg/solace/receiver_cache_request.go
@@ -33,17 +33,17 @@ type ReceiverCacheRequest interface {
 	// of this parameter is between 0 and signed int 32 max, with 0 indicating that there should be no restrictions on the age of messages
 	// to be retrieved.
 	NewCachedMessageSubscriptionRequest(cachedMessageSubscriptionStrategy cache.CachedMessageSubscriptionStrategy,
-		cacheName string, subscription resource.TopicSubscription, cacheAccessTimeout int32, maxCachedMessages int32,
+		cacheName string, subscription *resource.TopicSubscription, cacheAccessTimeout int32, maxCachedMessages int32,
 		cachedMessageAge int32) (cache.CachedMessageSubscriptionRequest, error)
 
 	// RequestCachedAsync asynchronously requests cached data from a cache, and
 	// defers processing of the resulting cache response to the application through
 	// the returned channel.
 	RequestCachedAsync(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
-		cacheRequestId message.CacheRequestID) <-chan cache.CacheResponse
+		cacheRequestID message.CacheRequestID) <-chan cache.CacheResponse
 
 	// RequestCachedAsyncWithCallback asynchronously requests cached data from a cache,
 	// and processes the resulting cache response through the provided function callback.
 	RequestCachedAsyncWithCallback(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
-		cacheRequestId message.CacheRequestID, callback func(cache.CacheResponse))
+		cacheRequestID message.CacheRequestID, callback func(cache.CacheResponse))
 }

--- a/pkg/solace/receiver_cache_request.go
+++ b/pkg/solace/receiver_cache_request.go
@@ -6,7 +6,7 @@ import (
 	"solace.dev/go/messaging/pkg/solace/resource"
 )
 
-// ReceiverCacheRequets Provides an interface through which the application can request cached messages from a cache.
+// ReceiverCacheRequest Provides an interface through which the application can request cached messages from a cache.
 // The cachedMessageSubscriptionRequest provides configuration for the impending cache request. Refer to [CachedMessageSubscriptionRequest] for more details.
 // The cacheRequestId provides an identifier that can be used to correlated received cached messages with a cache request and cache response. This cache request ID
 // MUST be unique for the duration of application execution, and it is the responsibility of the application to ensure this.

--- a/pkg/solace/receiver_cache_request.go
+++ b/pkg/solace/receiver_cache_request.go
@@ -1,0 +1,49 @@
+package solace
+
+import (
+	"solace.dev/go/messaging/pkg/solace/cache"
+	"solace.dev/go/messaging/pkg/solace/message"
+	"solace.dev/go/messaging/pkg/solace/resource"
+)
+
+// ReceiverCacheRequets Provides an interface through which the application can request cached messages from a cache.
+// The cachedMessageSubscriptionRequest provides configuration for the impending cache request. Refer to [CachedMessageSubscriptionRequest] for more details.
+// The cacheRequestId provides an identifier that can be used to correlated received cached messages with a cache request and cache response. This cache request ID
+// MUST be unique for the duration of application execution, and it is the responsibility of the application to ensure this.
+// This ID will be returned in either the function callback or channel, depdending on the chosen method.
+// The provided function callback or returned channel will provide to the application only the cache responses resulting from outstanding cache requests.
+// Data messages related to the cache response will be passed through the conventional [Receiver] interfaces of [Receive()] and [ReceiveAsync()].
+type ReceiverCacheRequest interface {
+	// NewCachedMessageSubscriptionRequest returns a CachedMessageSubscriptionRequest that can be used to configure a cache request
+	// and an error indicating whether or not the operation was successful. If the operation was successful the error is nil. Otherwise,
+	// the error will be non-nil and will indicate the reason the operation failed.
+	// The cachedMessageSubscriptionStrategy indicates how the API should pass received cached/live messages to the API after a cache
+	// request has been sent. Refer to [CachedMessageSubscriptionStrategy] for details on what behaviour each strategy configures.
+	// The cache_name parameter indicates the name of the cache to retrieve messages from.
+	// The subscription parameter indicates what topic the cache request should match against
+	// The cacheAccessTimeout parameter indicates how long in milliseconds a cache request is permitted to take before it is internally
+	// cancelled. The valid range for this timeout is between 3000 and signed int 32 max. This value specifies a timer for the internal
+	// requests that occur between this API and a PubSub+ cache. A single call to a [ReceiverCacheRequests] interface method
+	// can lead to one or more of these internal requests. As long as each of these internal requests
+	// complete before the specified time-out, the timeout value is satisfied.
+	// The maxCachedMessages parameter indicates the max number of messages expected to be returned as a part of a cache response. The range
+	// of this paramater is between 0 and signed int32 max, with 0 indicating that there should be no restrictions on the number of messages
+	// received as a part of a cache request.
+	// The cachedMessageAge parameter indicates the max age in seconds of the messages to be retrieved from a cache. The range
+	// of this parameter is between 0 and signed int 32 max, with 0 indicating that there should be no restrictions on the age of messages
+	// to be retrieved.
+	NewCachedMessageSubscriptionRequest(cachedMessageSubscriptionStrategy cache.CachedMessageSubscriptionStrategy,
+		cacheName string, subscription resource.TopicSubscription, cacheAccessTimeout int32, maxCachedMessages int32,
+		cachedMessageAge int32) (cache.CachedMessageSubscriptionRequest, error)
+
+	// RequestCachedAsync asynchronously requests cached data from a cache, and
+	// defers processing of the resulting cache response to the application through
+	// the returned channel.
+	RequestCachedAsync(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
+		cacheRequestId message.CacheRequestID) <-chan cache.CacheResponse
+
+	// RequestCachedAsyncWithCallback asynchronously requests cached data from a cache,
+	// and processes the resulting cache response through the provided function callback.
+	RequestCachedAsyncWithCallback(cachedMessageSubscriptionRequest cache.CachedMessageSubscriptionRequest,
+		cacheRequestId message.CacheRequestID, callback func(cache.CacheResponse))
+}


### PR DESCRIPTION
**Changes:**

- EBP-16: As a developer, I can instantiate a cache request configuration for all variations.
- Added unit tests for the cache request configuration story