### PR TITLE
EBP-368: bumped up the Go API version to 1.8.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -23,4 +23,4 @@ func init() {
 	core.SetVersion(version)
 }
 
-const version = "1.7.0"
+const version = "1.8.0"


### PR DESCRIPTION
**Changes:**
- EBP-368: bumped up the Go API version to 1.8.0