### PR TITLE
EBP-472: Test for max cached messages

### DIFF
--- a/test/helpers/cache_helpers.go
+++ b/test/helpers/cache_helpers.go
@@ -94,7 +94,7 @@ func SendMsgsToTopic(topic string, numMessages int) {
 	}
 	for i := 0; i < numMessages; i++ {
 		var receivedMessage message.InboundMessage
-		Eventually(receivedMsgs, "5000ms").Should(Receive(&receivedMessage))
+		Eventually(receivedMsgs, "5s").Should(Receive(&receivedMessage), fmt.Sprintf("Timed out waiting to receive message %d of %d", i, numMessages))
 		Expect(receivedMessage.GetDestinationName()).To(Equal(topic))
 	}
 }


### PR DESCRIPTION
Added test for verifying that the configured number of max cached messages are received as a result of a cache request.