### PR TITLE
EBP-474: Test for large cached messages

### DIFF
--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -792,6 +792,10 @@ var _ = Describe("Cache Strategy", func() {
 					/* EBP-21: Assert this is a cached message. */
 				}
 				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsSent)).To(BeNumerically("==", 1))
+				/* NOTE: This metric is incremented by CCSMP, and appears to be incremented for every portion of the
+				 * response that is received. Because the messages are very large, their parent response is split
+				 * across 6 portions.
+				 */
 				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsSucceeded)).To(BeNumerically("==", 6))
 				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsFailed)).To(BeNumerically("==", 0))
 			})

--- a/test/cache_test.go
+++ b/test/cache_test.go
@@ -733,29 +733,44 @@ var _ = Describe("Cache Strategy", func() {
 				 * we are not always having data returned exactly on the boundary of 1Mb.
 				 */
 				numExpectedCacheMessages := 28
-				payload := strings.Repeat("a", 30000)
-				outboundMessage, err := messagingService.MessageBuilder().BuildWithStringPayload(payload)
-				Expect(err).To(BeNil())
-				Expect(outboundMessage).ToNot(BeNil())
-				publishTopic := fmt.Sprintf("MaxMsgs10/%s/data1", testcontext.Cache().Vpn)
-				/* NOTE: Intiialize the cache with very large messages. This will be overwritten by the next test,
-				 * so we don't need to worry about long messages causing other tests to take longer.
-				 */
-				for i := 0; i < 10; i++ {
-					messagePublisher.Publish(outboundMessage, resource.TopicOf(publishTopic))
-				}
-				cacheRequestID := message.CacheRequestID(1)
-				cacheName := "MaxMsgs10"
-				cacheTopic := fmt.Sprintf("MaxMsgs*/%s/>", testcontext.Cache().Vpn)
-				cacheRequestConfig := resource.NewCachedMessageSubscriptionRequest(resource.AsAvailable, cacheName, resource.TopicSubscriptionOf(cacheTopic), 20000, 0, 0)
+				payload := strings.Repeat("a", 300000)
 				/* WARNING: If a topic subscription is added to one of the cache clusters that causes it to
 				 * attract more messages, then this buffer may not be big enough, and receiver termination will
 				 * hang.
 				 */
 				receivedMsgChan := make(chan message.InboundMessage, 30)
-				err = receiver.ReceiveAsync(func(msg message.InboundMessage) {
+				err := receiver.ReceiveAsync(func(msg message.InboundMessage) {
 					receivedMsgChan <- msg
 				})
+				outboundMessage, err := messagingService.MessageBuilder().BuildWithStringPayload(payload)
+				Expect(err).To(BeNil())
+				Expect(outboundMessage).ToNot(BeNil())
+				publishTopic := fmt.Sprintf("MaxMsgs10/%s/data1", testcontext.Cache().Vpn)
+				err = receiver.AddSubscription(resource.TopicSubscriptionOf(publishTopic))
+				Expect(err).To(BeNil())
+				/* NOTE: Intiialize the cache with very large messages. This will be overwritten by the next test,
+				 * so we don't need to worry about long messages causing other tests to take longer.
+				 */
+				numSentMessages := 10
+				for i := 0; i < numSentMessages; i++ {
+					messagePublisher.Publish(outboundMessage, resource.TopicOf(publishTopic))
+				}
+				for i := 0; i < numSentMessages; i++ {
+					var msg message.InboundMessage
+					Eventually(receivedMsgChan, "10s").Should(Receive(&msg))
+					Expect(msg).ToNot(BeNil())
+					Expect(msg.GetDestinationName()).To(Equal(publishTopic))
+					id, ok := msg.GetCacheRequestID()
+					Expect(ok).To(BeFalse())
+					Expect(id).To(BeNumerically("==", 0))
+					/* EBP-21: Assert this is a live message */
+				}
+				err = receiver.RemoveSubscription(resource.TopicSubscriptionOf(publishTopic))
+				Expect(err).To(BeNil())
+				cacheRequestID := message.CacheRequestID(1)
+				cacheName := "MaxMsgs10"
+				cacheTopic := fmt.Sprintf("MaxMsgs*/%s/>", testcontext.Cache().Vpn)
+				cacheRequestConfig := resource.NewCachedMessageSubscriptionRequest(resource.AsAvailable, cacheName, resource.TopicSubscriptionOf(cacheTopic), 20000, 0, 0)
 				Expect(err).To(BeNil())
 				channel, err := receiver.RequestCachedAsync(cacheRequestConfig, cacheRequestID)
 				Expect(err).To(BeNil())
@@ -768,7 +783,6 @@ var _ = Describe("Cache Strategy", func() {
 				/* EBP-28: Assert err from response is nil. */
 				var msg message.InboundMessage
 				for i := 0; i < numExpectedCacheMessages; i++ {
-					fmt.Printf("Received message %d\n", i)
 					Eventually(receivedMsgChan, "5s").Should(Receive(&msg))
 					Expect(msg).ToNot(BeNil())
 					/* NOTE: Can't assert topic from received message because of wildcard in cache request. */
@@ -778,7 +792,7 @@ var _ = Describe("Cache Strategy", func() {
 					/* EBP-21: Assert this is a cached message. */
 				}
 				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsSent)).To(BeNumerically("==", 1))
-				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsSucceeded)).To(BeNumerically("==", 3))
+				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsSucceeded)).To(BeNumerically("==", 6))
 				Expect(messagingService.Metrics().GetValue(metrics.CacheRequestsFailed)).To(BeNumerically("==", 0))
 			})
 			It("live data that does not match an outstanding asynchronous cache request is delivered immediately", func() {

--- a/test/helpers/cache_helpers.go
+++ b/test/helpers/cache_helpers.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	ValidCachedMessageAge   int32 = 5
-	ValidMaxCachedMessages  int32 = 10
+	ValidCachedMessageAge   int32 = 0
+	ValidMaxCachedMessages  int32 = 0
 	ValidCacheAccessTimeout int32 = 5000
 )
 


### PR DESCRIPTION
Cache request that require multiple messages (Get Next) in reply.