### PR TITLE
Cache test stability

### DIFF
--- a/test/helpers/cache_helpers.go
+++ b/test/helpers/cache_helpers.go
@@ -70,7 +70,7 @@ func SendMsgsToTopic(topic string, numMessages int) {
 	}()
 	err = receiver.Start()
 	Expect(err).To(BeNil())
-	publisher, err := messagingService.CreateDirectMessagePublisherBuilder().OnBackPressureReject(0).Build()
+	publisher, err := messagingService.CreateDirectMessagePublisherBuilder().Build()
 	Expect(err).To(BeNil())
 	defer func() {
 		err := publisher.Terminate(0)


### PR DESCRIPTION
This PR is just to fix some test stability issues. We were using a receiver that had a default backpressure of 50 to handle 100000 messages, so some were getting dropped. This was missed in the initial testing because it usually passes locally, and because the default behaviour that the developer who wrote the test was accustomed to a backpressure strategy of elastic being used by default, as is the case in the PS+ Python API. There is no Jira for this fix atm.