### PR TITLE
EBP-490: Unsubscribe works

### DIFF
--- a/internal/impl/core/cache_requestor.go
+++ b/internal/impl/core/cache_requestor.go
@@ -206,7 +206,7 @@ type CacheRequestor interface {
 	DestroyCacheRequest(CacheRequest) error
 	// SendCacheRequest sends the given cache request object, and configures CCSMP to use the given callback to handle
 	// the resulting cache event/response
-	SendCacheRequest(CacheRequest, CoreCacheEventCallback) error
+	SendCacheRequest(CacheRequest, CoreCacheEventCallback, uintptr) error
 	// ProcessCacheEvent creates a cache response from the cache event that was asynchronously returned by CCSMP, and
 	// gives this response to the application for post-processing using the method configured by the application during
 	// the call to RequestCachedAsync or RequestCachedAsyncWithCallback.
@@ -220,7 +220,15 @@ type CacheRequestor interface {
 // SendCacheRequest sends a creates a cache session and sends a cache request on that session. This method
 // assumes the receiver is in the proper state (running). The caller must guarantee this state before
 // attempting to send a cache request. Failing to do so will result in undefined behaviour.
-func (receiver *ccsmpBackedReceiver) SendCacheRequest(cacheRequest CacheRequest, cacheEventCallback CoreCacheEventCallback) error {
+// dispatchID needs to be passed because the [DirectMessageReceiver] posesses a dispatch ID that can be
+// different from the one maintained by the [ccsmpBackedReceiver]. When the [DirectMessageReceiver] is started,
+// it increments the service-wide dispatchID that is maintained by the [ccsmpBackedReceiver], and maintains a
+// copy of that dispatchID for the remainder of its lifecycle. It is not documented that this copy of the
+// dispatchID is required to be immutable, and it is the [DirectMessageReceiver]'s responsibility to
+// maintain it across network operations. If the dispatchID were not passed, and the
+// [ccsmpBackedReceiver.dispatchID] was used instead, then the data messages from the cache response would be
+// forwarded to the last created [DirectMessageReceiver] instead of to the one which sent this cache request.
+func (receiver *ccsmpBackedReceiver) SendCacheRequest(cacheRequest CacheRequest, cacheEventCallback CoreCacheEventCallback, dispatchID uintptr) error {
 	var err error
 
 	cacheSession := cacheRequest.CacheSession()
@@ -231,9 +239,9 @@ func (receiver *ccsmpBackedReceiver) SendCacheRequest(cacheRequest CacheRequest,
 		return solace.NewError(&solace.IllegalArgumentError{}, errorString, nil)
 	}
 	if logging.Default.IsDebugEnabled() {
-		logging.Default.Debug(fmt.Sprintf("Sending cache request with cache request ID %d on cache session %s", cacheRequest.ID(), cacheSession.String()))
+		logging.Default.Debug(fmt.Sprintf("Sending cache request with cache request ID %d and dispatchID 0x%x on cache session %s", cacheRequest.ID(), dispatchID, cacheSession.String()))
 	}
-	errInfo := cacheSession.SendCacheRequest(uintptr(receiver.dispatchID),
+	errInfo := cacheSession.SendCacheRequest(uintptr(dispatchID),
 		cacheRequest.RequestConfig().GetName(),
 		cacheRequest.ID(),
 		ccsmp.CachedMessageSubscriptionRequestStrategyMappingToCCSMPCacheRequestFlags[*cacheStrategy],

--- a/internal/impl/receiver/direct_message_receiver_impl.go
+++ b/internal/impl/receiver/direct_message_receiver_impl.go
@@ -1030,7 +1030,7 @@ func (receiver *directMessageReceiverImpl) RequestCachedAsync(cachedMessageSubsc
 		atomic.AddInt64(&receiver.numOutstandingCacheRequests, -1)
 		return nil, err
 	}
-	err = receiver.internalReceiver.CacheRequestor().SendCacheRequest(cacheRequest, cacheEventCallback)
+	err = receiver.internalReceiver.CacheRequestor().SendCacheRequest(cacheRequest, cacheEventCallback, receiver.dispatch)
 	if err != nil {
 		atomic.AddInt64(&receiver.numOutstandingCacheRequests, -1)
 		close(applicationChannel)
@@ -1073,7 +1073,7 @@ func (receiver *directMessageReceiverImpl) RequestCachedAsyncWithCallback(cached
 		atomic.AddInt64(&receiver.numOutstandingCacheRequests, -1)
 		return err
 	}
-	err = receiver.internalReceiver.CacheRequestor().SendCacheRequest(cacheRequest, cacheEventCallback)
+	err = receiver.internalReceiver.CacheRequestor().SendCacheRequest(cacheRequest, cacheEventCallback, receiver.dispatch)
 	if err != nil {
 		atomic.AddInt64(&receiver.numOutstandingCacheRequests, -1)
 		receiver.cacheRequestMap.Delete(cacheRequest.Index())

--- a/internal/impl/receiver/message_receiver_impl_test.go
+++ b/internal/impl/receiver/message_receiver_impl_test.go
@@ -297,7 +297,7 @@ type mockInternalReceiver struct {
 	incrementDuplicateAckCount     func()
 	newPersistentReceiver          func(props []string, callback core.RxCallback, eventCallback core.PersistentEventCallback) (core.PersistentReceiver, *ccsmp.SolClientErrorInfoWrapper)
 	processCacheResponseFunc       func(*mockInternalReceiver, *sync.Map, core.CoreCacheEventInfo)
-	sendCacheRequestFunc           func(*mockInternalReceiver, core.CacheRequest, core.CoreCacheEventCallback) error
+	sendCacheRequestFunc           func(*mockInternalReceiver, core.CacheRequest, core.CoreCacheEventCallback, uintptr) error
 	cancelPendingCacheRequestsFunc func(*mockInternalReceiver, core.CacheRequestMapIndex, core.CacheResponseProcessor) *core.CoreCacheEventInfo
 	createCacheRequestFunc         func(*mockInternalReceiver, resource.CachedMessageSubscriptionRequest, message.CacheRequestID, core.CacheResponseProcessor) (core.CacheRequest, error)
 	destroyCacheRequestFunc        func(*mockInternalReceiver, core.CacheRequest) error
@@ -323,9 +323,9 @@ func (mock *mockInternalReceiver) DestroyCacheRequest(cacheRequest core.CacheReq
 	return nil
 }
 
-func (mock *mockInternalReceiver) SendCacheRequest(cacheRequest core.CacheRequest, cacheEventCallback core.CoreCacheEventCallback) error {
+func (mock *mockInternalReceiver) SendCacheRequest(cacheRequest core.CacheRequest, cacheEventCallback core.CoreCacheEventCallback, dispatchID uintptr) error {
 	if mock.sendCacheRequestFunc != nil {
-		return mock.sendCacheRequestFunc(mock, cacheRequest, cacheEventCallback)
+		return mock.sendCacheRequestFunc(mock, cacheRequest, cacheEventCallback, dispatchID)
 	}
 	/* If not set, presume no-op is intended. */
 	return nil


### PR DESCRIPTION
Added test to verify that unsubscribe works, and to verify the behaviour of overlapping subscriptions before, during, and after cache requests.
A part of the test, the part for CachedOnly, is not applicable atm because message-filtering has not been implemented yet. I'll be working on that next and have left a note in the test to add coverage once CachedOnly is full featured. The message-filtering will be added as a part of EBP-23.