### PR TITLE
EBP-751: GHA ubuntu version update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
   # This workflow contains multiple jobs
   # this job sets up the oldest version of go to check lang compatibility
   CompatibilityCheck:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     #Steps for the compatiblity test
     steps:
       - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   # this job runs linux based tests
   Linux:
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
Updated test.yml workflow file to use ubuntu 24.04 instead of 20.04 in response to 20.04 brownout in advance of April 15, 2025 deprecation of the older version. An example of the problem that this PR solves can be found at https://github.com/SolaceDev/pubsubplus-go-client/actions/runs/14200170851?pr=114.