### PR TITLE
EBP-638: Go Cache test does not fail as expected

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -49,13 +49,13 @@ OAuth tests can be run when using testcontainers by exporting the variable OAUTH
 
 ### Cache
 Cache tests can be run when using testcontainers by exporting the variables:
-- PUBSUB_CACHE_HOSTNAME=<name of cache instance>
-- PUBSUB_CACHE_SUPSECT_HOSTNAME=<name of suspect cache instance>
-- PUBSUB_CACHE_TEST_IMAGE=<name of docker image for cache instances>
-- PUBSUB_CACHEPROXY_TEST_IMAGE=<name of docker image for cahce proxy instances>
+- `PUBSUB_CACHE_HOSTNAME=<name of cache instance>`
+- `PUBSUB_CACHE_SUPSECT_HOSTNAME=<name of suspect cache instance>`
+- `SOLCACHE_TEST_IMAGE=<name of docker image for cache instances>`
+- `SOLCACHEPROXY_TEST_IMAGE=<name of docker image for cahce proxy instances>`
 These environment variables are used to create and destroy the various docker containers that are required for testing. Modifying these variables after they have been used to create containers will lead to undefined behaviour and should not be done. Populating these variables during test execution should not be expected to cause the containers to be created partway through the tests, and will lead to undefined behaviour.
-PUBSUB_CACHE_HOSTNAME, PUBSUB_CACHE_SUPSECT_HOSTNAME, and PUBSUB_CACHE_TEST_IMAGE are all necessary to run cache tests.
-PUBSUB_CACHE_HOSTNAME, and PUBSUB_CACHEPROXY_TEST_IMAGE are all necessary to run cache proxy tests. For tests that use both cache and cache proxy, all four variables are needed. Cache suspect is just a specfially configured cache instance, so tests that use suspect cache have the same requirements as those that use cache.
+PUBSUB_CACHE_HOSTNAME, PUBSUB_CACHE_SUPSECT_HOSTNAME, and SOLCACHE_TEST_IMAGE are all necessary to run cache tests.
+PUBSUB_CACHE_HOSTNAME, and SOLCACHEPROXY_TEST_IMAGE are all necessary to run cache proxy tests. For tests that use both cache and cache proxy, all four variables are needed. Cache suspect is just a specfially configured cache instance, so tests that use suspect cache have the same requirements as those that use cache.
 The docker images for cache and suspect cache instances are the same. The docker images for cache and cache proxy are distinct. The cache docker image is proprietary and can only be gotten through a purchased product key. The docker image for cache proxy is proprietary, for internal use only, and not available to the general public.
 
 ### Running the tests from inside a docker container

--- a/test/data/compose/docker-compose.cache.yml
+++ b/test/data/compose/docker-compose.cache.yml
@@ -1,6 +1,6 @@
 version: '3.5'
 
-# Additive compose file for solacche related services
+# Additive compose file for solcache related services
 # This requires the docker-compose.yml file
 
 networks:

--- a/test/data/config/config_remote.json
+++ b/test/data/config/config_remote.json
@@ -4,5 +4,5 @@
     },
     "semp": {
         "host": "localhost"
-    },
+    }
 }

--- a/test/helpers/cache_helpers.go
+++ b/test/helpers/cache_helpers.go
@@ -94,7 +94,7 @@ func SendMsgsToTopic(topic string, numMessages int) {
 	}
 	for i := 0; i < numMessages; i++ {
 		var receivedMessage message.InboundMessage
-		Eventually(receivedMsgs, "5s").Should(Receive(&receivedMessage), fmt.Sprintf("Timed out waiting to receive message %d of %d", i, numMessages))
+		Eventually(receivedMsgs, "10s").Should(Receive(&receivedMessage), fmt.Sprintf("Timed out waiting to receive message %d of %d", i, numMessages))
 		Expect(receivedMessage.GetDestinationName()).To(Equal(topic))
 	}
 }


### PR DESCRIPTION
**Changes:**

- EBP-638: Corrected a typo in the ReadMe
- EBP-638: Updated the test cases to reenable the commented out tests