### PR TITLE
EBP-649: Go API partitioned queue test prints to console

### DIFF
--- a/test/partitioned_queue_test.go
+++ b/test/partitioned_queue_test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"solace.dev/go/messaging"
@@ -102,7 +103,7 @@ var _ = Describe("Partitioned Queue Tests", func() {
 
 			messageHandler := func(message message.InboundMessage) {
 				// count the received messages dispatched for the receiver
-				receivedMessageCount += 1
+				atomic.AddUint64(&receivedMessageCount, 1)
 			}
 
 			receiverOne.ReceiveAsync(messageHandler)

--- a/test/partitioned_queue_test.go
+++ b/test/partitioned_queue_test.go
@@ -17,7 +17,6 @@
 package test
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
@@ -58,6 +57,7 @@ var _ = Describe("Partitioned Queue Tests", func() {
 			var messagingServices [4]solace.MessagingService
 			var partitionKeys [9]string
 			var rebalanceDelayDuration = time.Duration(rebalanceDelay) * 2
+			var receivedMessageCount uint64 = 0
 
 			//generate partition keys
 			for i := 0; i < 9; i++ {
@@ -101,7 +101,8 @@ var _ = Describe("Partitioned Queue Tests", func() {
 			publisher.Terminate(rebalanceDelayDuration * time.Second)
 
 			messageHandler := func(message message.InboundMessage) {
-				fmt.Println("message received")
+				// count the received messages dispatched for the receiver
+				receivedMessageCount += 1
 			}
 
 			receiverOne.ReceiveAsync(messageHandler)
@@ -129,6 +130,10 @@ var _ = Describe("Partitioned Queue Tests", func() {
 				totalMessagesReceived := receiverOneMetrics.
 					GetValue(metrics.PersistentMessagesReceived) + receiverTwoMetrics.GetValue(metrics.PersistentMessagesReceived) + receiverThreeMetrics.GetValue(metrics.PersistentMessagesReceived)
 				return totalMessagesReceived
+			}).WithTimeout(rebalanceDelayDuration * time.Second).Should(Equal(publisherMetrics.GetValue(metrics.TotalMessagesSent)))
+
+			Eventually(func() uint64 {
+				return receivedMessageCount // what was actually received in the API callback
 			}).WithTimeout(rebalanceDelayDuration * time.Second).Should(Equal(publisherMetrics.GetValue(metrics.TotalMessagesSent)))
 
 			Expect(receiverOne.Terminate(10 * time.Second)).ToNot(HaveOccurred())
@@ -279,7 +284,6 @@ var _ = Describe("Partitioned Queue Tests", func() {
 			receiverTwo, _ := messagingServices[2].CreatePersistentMessageReceiverBuilder().
 				WithSubscriptions(resource.TopicSubscriptionOf(topicName)).Build(partitionedQueue)
 			receiverTwoMessageHandler := func(message message.InboundMessage) {
-				//fmt.Println("Received message in receiverTwo")
 				// count the received messages dispatched for the receiver
 				receiverTwoMessageCount += 1
 			}


### PR DESCRIPTION
**Changes:**
- EBP-649: Go API partitioned queue test prints to console
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhances partitioned queue testing by adding atomic message counting to verify accurate message reception across multiple receivers.

Main changes:
- Adds atomic counter to track received messages in messageHandler
- Implements additional verification of message delivery using atomic counter
- Removes unnecessary fmt.Println debugging statement from receiver code

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
