### PR TITLE
EBP-1223: Unpin the Go runtime version for the Alpine Linux musl node on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,15 +39,11 @@ builder.goapi([
   "validationGoVer": 'auto-v1.17.x',
   "getTestPermutations": {
     List<List<String>> permutations = []
-    for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.DARWIN_X86_64,  builder.DARWIN_ARM]) {
+    for (platform in [builder.LINUX_ARM, builder.LINUX_X86_64, builder.DARWIN_X86_64,  builder.DARWIN_ARM, builder.LINUX_MUSL]) {
       for (gover in ['auto-latest', 'auto-previous']) {
         permutations << [platform, gover]
       }
     }
-    // run tests on the last stable Go version (1.22.4) for linux musl
-    // See EBP-46
-    // and this issue here - https://go-review.googlesource.com/c/go/+/600296
-    permutations << [builder.LINUX_MUSL, 'auto-v1.22.4']
     return permutations
   }
 ]) 


### PR DESCRIPTION
**Changes:**
- EBP-1223: Unpin the Go runtime version for the Alpine Linux musl node on Jenkins
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Jenkins build configuration to use dynamic Go versions for Alpine Linux musl platform instead of pinned version.
Main changes:
- Removed pinned Go version 1.22.4 for Linux musl platform
- Added Linux musl to standard platform permutation loop with latest/previous Go versions
- Eliminated special case handling that was added due to previous Go issue

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
