### PR TITLE
EBP-13: upgrade git-actions to use docker-compose v2 in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,11 +40,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
-      - name: Install Compose
-        uses: ndeloof/install-compose-action@v0.0.1
-        with:
-          version: v2.29.1 # pinned to 'latest' as of 06/08/2024
-          legacy: true    # will also install in PATH as `docker-compose`
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.3
         with:


### PR DESCRIPTION
**Changes:**
- EBP-13: upgrade git-actions to use docker-compose v2 in tests

PS: Github actions has v2 of docker (with compose) installed on the runner nodes by default so we will leverage that.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove outdated docker-compose installation step from GitHub Actions workflow to leverage Docker Compose v2 available in GitHub runners.

Main changes:
- Removed ndeloof/install-compose-action step that was installing Docker Compose v2.29.1

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
