### PR TITLE
EBP-1981: Clean up resources when persistent receiver fails to start

### DIFF
--- a/internal/ccsmp/ccsmp_flow.go
+++ b/internal/ccsmp/ccsmp_flow.go
@@ -121,6 +121,7 @@ func (session *SolClientSession) SolClientSessionCreateFlow(properties []string,
 			C.solClient_uint64_t(flowID))
 	})
 	if err != nil {
+		flow.SolClientFlowRemoveCallbacks()
 		return nil, err
 	}
 	return flow, nil

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -363,15 +363,6 @@ func (receiver *persistentMessageReceiverImpl) cleanupRuntimeSubscriptions() {
 	}
 }
 
-// awaitEventExecutorTermination waits for the event executor to finish terminating.
-// This is a blocking call and should only be used during graceful termination.
-// For ungraceful termination, use cleanupConstructionResources() which terminates
-// the executor without waiting.
-func (receiver *persistentMessageReceiverImpl) awaitEventExecutorTermination() {
-	receiver.logger.Debug("Awaiting termination of event executor")
-	receiver.eventExecutor.AwaitTermination()
-}
-
 // Terminate will terminate the service gracefully and synchronously.
 // This function is idempotent. The only way to resume operation
 // after this function is called is to create a new instance.
@@ -412,8 +403,11 @@ func (receiver *persistentMessageReceiverImpl) Terminate(gracePeriod time.Durati
 	}
 	// Remove the termination event handler
 	receiver.internalReceiver.Events().RemoveEventHandler(receiver.terminationHandlerID)
-	// Defer executor await after removing event handler, maintaining original code structure
-	defer receiver.awaitEventExecutorTermination()
+	defer func() {
+		receiver.logger.Debug("Awaiting termination of event executor")
+		// Allow the event executor to terminate, blocking until it does
+		receiver.eventExecutor.AwaitTermination()
+	}()
 	// Unblock the receiver dispatch routine telling it to not continue
 	select {
 	case receiver.rxCallbackSet <- false:

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -214,10 +214,10 @@ func (receiver *persistentMessageReceiverImpl) Start() (err error) {
 			receiver.logger.Debug("Start receiver complete")
 		} else {
 			receiver.logger.Debug("Start receiver complete with error: " + err.Error())
-			receiver.internalReceiver.Events().RemoveEventHandler(receiver.terminationHandlerID)
-			if receiver.internalFlow != nil {
-				receiver.internalFlow.Destroy(true)
-			}
+			// Clean up resources allocated during construction
+			receiver.cleanupConstructionResources()
+			// Clean up resources allocated during start
+			receiver.cleanupStartResources()
 			receiver.terminated(nil)
 			receiver.startFuture.Complete(err)
 		}
@@ -314,6 +314,64 @@ func (receiver *persistentMessageReceiverImpl) StartAsyncCallback(callback func(
 	}()
 }
 
+// cleanupConstructionResources cleans up resources allocated during receiver construction.
+// This includes resources allocated in the construct() method:
+// - Event executor
+// - Message buffer channel
+// This method should be called when the receiver fails to start or during termination.
+func (receiver *persistentMessageReceiverImpl) cleanupConstructionResources() {
+	// Terminate the event executor
+	receiver.eventExecutor.Terminate()
+
+	// Close the buffer channel to prevent any further messages from being added
+	// This may result in a panic in the rx callback that gets handled and logged
+	close(receiver.buffer)
+	atomic.StoreInt32(&receiver.bufferClosed, 1)
+}
+
+// cleanupStartResources cleans up resources allocated during receiver startup.
+// This includes resources allocated in the Start() method:
+// - Event handler registration
+// - Internal flow
+// This method should be called when the receiver fails to start.
+func (receiver *persistentMessageReceiverImpl) cleanupStartResources() {
+	// Remove the termination event handler
+	receiver.internalReceiver.Events().RemoveEventHandler(receiver.terminationHandlerID)
+	// Destroy the internal flow
+	receiver.destroyInternalFlow()
+}
+
+// destroyInternalFlow destroys the internal flow and logs any errors.
+func (receiver *persistentMessageReceiverImpl) destroyInternalFlow() {
+	if receiver.internalFlow != nil {
+		errInfoWrapper := receiver.internalFlow.Destroy(true)
+		if errInfoWrapper != nil {
+			receiver.logger.Info("Encountered error while trying to clean up receiver flow: " + errInfoWrapper.String())
+		}
+	}
+}
+
+// cleanupRuntimeSubscriptions cleans up subscription correlations that were
+// added during runtime via AddSubscription/RemoveSubscription.
+// This should only be called during graceful termination.
+func (receiver *persistentMessageReceiverImpl) cleanupRuntimeSubscriptions() {
+	receiver.outstandingSubscriptionEventsLock.Lock()
+	defer receiver.outstandingSubscriptionEventsLock.Unlock()
+	for k := range receiver.outstandingSubscriptionEvents {
+		receiver.internalReceiver.ClearSubscriptionCorrelation(k)
+		delete(receiver.outstandingSubscriptionEvents, k)
+	}
+}
+
+// awaitEventExecutorTermination waits for the event executor to finish terminating.
+// This is a blocking call and should only be used during graceful termination.
+// For ungraceful termination, use cleanupConstructionResources() which terminates
+// the executor without waiting.
+func (receiver *persistentMessageReceiverImpl) awaitEventExecutorTermination() {
+	receiver.logger.Debug("Awaiting termination of event executor")
+	receiver.eventExecutor.AwaitTermination()
+}
+
 // Terminate will terminate the service gracefully and synchronously.
 // This function is idempotent. The only way to resume operation
 // after this function is called is to create a new instance.
@@ -338,23 +396,10 @@ func (receiver *persistentMessageReceiverImpl) Terminate(gracePeriod time.Durati
 			receiver.logger.Debug("Terminate receiver complete")
 		}
 	}()
-	defer func() {
-		// Last thing we want to do is destroy the flow
-		errInfoWrapper := receiver.internalFlow.Destroy(true)
-		if errInfoWrapper != nil {
-			// We should not encounter issues destroying the flow
-			receiver.logger.Info("Encountered error while trying to clean up receiver flow: " + errInfoWrapper.String())
-		}
-	}()
-	defer func() {
-		// we still might get subscription responses so we'll delay as long as possible
-		receiver.outstandingSubscriptionEventsLock.Lock()
-		defer receiver.outstandingSubscriptionEventsLock.Unlock()
-		for k := range receiver.outstandingSubscriptionEvents {
-			receiver.internalReceiver.ClearSubscriptionCorrelation(k)
-			delete(receiver.outstandingSubscriptionEvents, k)
-		}
-	}()
+	// Clean up flow - this is done in defer to ensure it happens last
+	defer receiver.destroyInternalFlow()
+	// Clean up runtime subscriptions added via AddSubscription/RemoveSubscription
+	defer receiver.cleanupRuntimeSubscriptions()
 	// First set the internal flow stopped to terminating state, this way we will never resume flow
 	// as we must do an atomic compare and set to call start or stop.
 	// Note that there is a potential race here where we change the flow stopped state after the check and
@@ -367,11 +412,8 @@ func (receiver *persistentMessageReceiverImpl) Terminate(gracePeriod time.Durati
 	}
 	// Remove the termination event handler
 	receiver.internalReceiver.Events().RemoveEventHandler(receiver.terminationHandlerID)
-	defer func() {
-		receiver.logger.Debug("Awaiting termination of event executor")
-		// Allow the event executor to terminate, blocking until it does
-		receiver.eventExecutor.AwaitTermination()
-	}()
+	// Defer executor await after removing event handler, maintaining original code structure
+	defer receiver.awaitEventExecutorTermination()
 	// Unblock the receiver dispatch routine telling it to not continue
 	select {
 	case receiver.rxCallbackSet <- false:
@@ -442,12 +484,9 @@ func (receiver *persistentMessageReceiverImpl) unsolicitedTermination(eventInfo 
 	receiver.internalFlow.Destroy(shouldCleanUpNative)
 	// Remove the event handler
 	receiver.internalReceiver.Events().RemoveEventHandler(receiver.terminationHandlerID)
-	// Shutdown the event executor but do not wait for remaining events to be processed
-	receiver.eventExecutor.Terminate()
-	// Block any new messages from making it into the buffer
-	// This may result in a panic in the rx callback that gets handled and logged
-	close(receiver.buffer)
-	atomic.StoreInt32(&receiver.bufferClosed, 1)
+
+	// Clean up construction resources (executor and buffer)
+	receiver.cleanupConstructionResources()
 
 	// Unblock the receiver dispatch routine telling it to not continue
 	select {

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -214,10 +214,10 @@ func (receiver *persistentMessageReceiverImpl) Start() (err error) {
 			receiver.logger.Debug("Start receiver complete")
 		} else {
 			receiver.logger.Debug("Start receiver complete with error: " + err.Error())
-			// Clean up resources allocated during construction
-			receiver.cleanupConstructionResources()
-			// Clean up resources allocated during start
+			// Clean up start resources first (stop flow)
 			receiver.cleanupStartResources()
+			// Then clean up construction resources (close buffer and terminate executor)
+			receiver.cleanupConstructionResources()
 			receiver.terminated(nil)
 			receiver.startFuture.Complete(err)
 		}
@@ -327,6 +327,11 @@ func (receiver *persistentMessageReceiverImpl) cleanupConstructionResources() {
 	// This may result in a panic in the rx callback that gets handled and logged
 	close(receiver.buffer)
 	atomic.StoreInt32(&receiver.bufferClosed, 1)
+
+	// Drain any messages that were queued before close and free their native memory
+	for msg := range receiver.buffer {
+		ccsmp.SolClientMessageFree(&msg)
+	}
 }
 
 // cleanupStartResources cleans up resources allocated during receiver startup.

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -396,7 +396,7 @@ func (receiver *persistentMessageReceiverImpl) Terminate(gracePeriod time.Durati
 			receiver.logger.Debug("Terminate receiver complete")
 		}
 	}()
-	// Clean up flow - this is done in defer to ensure it happens last
+	// Clean up flow
 	defer receiver.destroyInternalFlow()
 	// Clean up runtime subscriptions added via AddSubscription/RemoveSubscription
 	defer receiver.cleanupRuntimeSubscriptions()

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -218,6 +218,8 @@ func (receiver *persistentMessageReceiverImpl) Start() (err error) {
 			receiver.cleanupStartResources()
 			// Then clean up construction resources (close buffer and terminate executor)
 			receiver.cleanupConstructionResources()
+			// Drain any messages that were queued before close and free their native memory
+			receiver.drainQueue()
 			receiver.terminated(nil)
 			receiver.startFuture.Complete(err)
 		}
@@ -327,11 +329,6 @@ func (receiver *persistentMessageReceiverImpl) cleanupConstructionResources() {
 	// This may result in a panic in the rx callback that gets handled and logged
 	close(receiver.buffer)
 	atomic.StoreInt32(&receiver.bufferClosed, 1)
-
-	// Drain any messages that were queued before close and free their native memory
-	for msg := range receiver.buffer {
-		ccsmp.SolClientMessageFree(&msg)
-	}
 }
 
 // cleanupStartResources cleans up resources allocated during receiver startup.

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -218,7 +218,9 @@ func (receiver *persistentMessageReceiverImpl) Start() (err error) {
 			receiver.cleanupStartResources()
 			// Then clean up construction resources (close buffer and terminate executor)
 			receiver.cleanupConstructionResources()
-			// Drain any messages that were queued before close and free their native memory
+			// Drain any messages that were queued before close and free their native memory.
+			// This is necessary because the architecture permits subscriptions to be added to a
+			// receiver before Start() is called
 			receiver.drainQueue()
 			receiver.terminated(nil)
 			receiver.startFuture.Complete(err)

--- a/internal/impl/receiver/persistent_message_receiver_impl.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl.go
@@ -214,10 +214,14 @@ func (receiver *persistentMessageReceiverImpl) Start() (err error) {
 			receiver.logger.Debug("Start receiver complete")
 		} else {
 			receiver.logger.Debug("Start receiver complete with error: " + err.Error())
-			// Clean up start resources first (stop flow)
-			receiver.cleanupStartResources()
-			// Then clean up construction resources (close buffer and terminate executor)
+			// Terminate the executor first so that no flow-event callbacks (submitted via
+			// onFlowEvent → eventExecutor.Submit) can be queued after we destroy the flow.
+			// SolClientFlowDestroy (called inside cleanupStartResources) can fire synchronous
+			// C-level events that reach onFlowEvent while the executor is still live, causing
+			// a race between Submit and the channel close in Terminate.
 			receiver.cleanupConstructionResources()
+			// Now safe to destroy the flow; any Submit() calls from C callbacks will be rejected.
+			receiver.cleanupStartResources()
 			// Drain any messages that were queued before close and free their native memory.
 			// This is necessary because the architecture permits subscriptions to be added to a
 			// receiver before Start() is called

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -1247,9 +1247,9 @@ func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
 		t.Error("Flow was not destroyed")
 	}
 
-    // Verify buffer channel is closed by checking the atomic flag.
-    // This proves cleanupConstructionResources() was called, which also
-    // terminates the event executor (called before closing the buffer)
+	// Verify buffer channel is closed by checking the atomic flag.
+	// This proves cleanupConstructionResources() was called, which also
+	// terminates the event executor (called before closing the buffer)
 	if atomic.LoadInt32(&receiverImpl.bufferClosed) != 1 {
 		t.Error("Buffer channel should be closed")
 	}

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -18,6 +18,7 @@ package receiver
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1182,4 +1183,77 @@ func TestPersistentReceiverUnsolicitedTermination(t *testing.T) {
 	if !metricsIncremented {
 		t.Error("metrics not incremented on incomplete delivery")
 	}
+}
+
+// TestPersistentReceiverMultipleFailedStartsNoLeak verifies that resources
+// are properly cleaned up when a receiver fails to start
+//
+// This test:
+// 1. Creates a receiver (allocates: executor + channel)
+// 2. Fails to start
+// 3. Verifies cleanup by checking goroutine count (executor termination)
+//
+// If cleanup doesn't work, the event executor goroutine would leak.
+func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
+	// Capture initial goroutine count to detect leaks
+	initialGoroutines := runtime.NumGoroutine()
+
+	// Setup mocks
+	internalFlow := &mockPersistentReceiver{}
+	internalReceiver := &mockInternalReceiver{}
+
+	// Flow will fail to start
+	internalFlow.start = func() *ccsmp.SolClientErrorInfoWrapper {
+		return ccsmp.NewInternalSolClientErrorInfoWrapper(ccsmp.SolClientReturnCodeFail, ccsmp.SolClientSubCode(1), ccsmp.SolClientResponseCode(0), "Simulated failure")
+	}
+
+	flowDestroyed := false
+	internalFlow.destroy = func(freeMemory bool) *ccsmp.SolClientErrorInfoWrapper {
+		flowDestroyed = true
+		return nil
+	}
+
+	internalReceiver.newPersistentReceiver = func(props []string, callback core.RxCallback, eventCallback core.PersistentEventCallback) (core.PersistentReceiver, core.ErrorInfo) {
+		return internalFlow, nil
+	}
+
+	// Build receiver
+	builder := &persistentMessageReceiverBuilderImpl{
+		internalReceiver: internalReceiver,
+		properties:       constants.DefaultPersistentReceiverProperties.GetConfiguration(),
+	}
+
+	receiver, err := builder.Build(resource.QueueDurableExclusive("test-queue"))
+	if err != nil {
+		t.Fatalf("Failed to build receiver: %v", err)
+	}
+
+	// Attempt to start - should fail
+	err = receiver.Start()
+	if err == nil {
+		t.Fatal("Expected Start() to fail")
+	}
+
+	// Verify receiver is terminated
+	if !receiver.IsTerminated() {
+		t.Error("Receiver should be terminated after failed start")
+	}
+
+	// Verify flow was destroyed
+	if !flowDestroyed {
+		t.Error("Flow was not destroyed")
+	}
+
+	// Force GC to clean up any remaining references
+	runtime.GC()
+
+	// Verify no goroutine leak
+	finalGoroutines := runtime.NumGoroutine()
+	goroutineDiff := finalGoroutines - initialGoroutines
+	if goroutineDiff != 0 {
+		t.Errorf("Goroutine leak detected: started with %d, ended with %d (diff: %d)",
+			initialGoroutines, finalGoroutines, goroutineDiff)
+	}
+
+	t.Logf("Goroutine count: initial=%d, final=%d, diff=%d", initialGoroutines, finalGoroutines, goroutineDiff)
 }

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -1185,7 +1185,7 @@ func TestPersistentReceiverUnsolicitedTermination(t *testing.T) {
 	}
 }
 
-// TestPersistentReceiverMultipleFailedStartsNoLeak verifies that resources
+// TestPersistentReceiverFailedStartResourceCleanup verifies that resources
 // are properly cleaned up when a receiver fails to start
 //
 // This test verifies the bug fix by checking that:
@@ -1195,7 +1195,7 @@ func TestPersistentReceiverUnsolicitedTermination(t *testing.T) {
 //
 // These checks prove that cleanupConstructionResources() and cleanupStartResources()
 // were called, which means the executor was terminated and resources were freed.
-func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
+func TestPersistentReceiverFailedStartResourceCleanup(t *testing.T) {
 	// Setup mocks
 	internalFlow := &mockPersistentReceiver{}
 	internalReceiver := &mockInternalReceiver{}

--- a/internal/impl/receiver/persistent_message_receiver_impl_test.go
+++ b/internal/impl/receiver/persistent_message_receiver_impl_test.go
@@ -18,7 +18,7 @@ package receiver
 
 import (
 	"fmt"
-	"runtime"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1188,16 +1188,14 @@ func TestPersistentReceiverUnsolicitedTermination(t *testing.T) {
 // TestPersistentReceiverMultipleFailedStartsNoLeak verifies that resources
 // are properly cleaned up when a receiver fails to start
 //
-// This test:
-// 1. Creates a receiver (allocates: executor + channel)
-// 2. Fails to start
-// 3. Verifies cleanup by checking goroutine count (executor termination)
+// This test verifies the bug fix by checking that:
+// 1. The flow is destroyed
+// 2. The receiver is terminated
+// 3. The buffer channel is closed
 //
-// If cleanup doesn't work, the event executor goroutine would leak.
+// These checks prove that cleanupConstructionResources() and cleanupStartResources()
+// were called, which means the executor was terminated and resources were freed.
 func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
-	// Capture initial goroutine count to detect leaks
-	initialGoroutines := runtime.NumGoroutine()
-
 	// Setup mocks
 	internalFlow := &mockPersistentReceiver{}
 	internalReceiver := &mockInternalReceiver{}
@@ -1228,14 +1226,19 @@ func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
 		t.Fatalf("Failed to build receiver: %v", err)
 	}
 
+	receiverImpl, ok := receiver.(*persistentMessageReceiverImpl)
+	if !ok {
+		t.Fatal("Expected persistentMessageReceiverImpl")
+	}
+
 	// Attempt to start - should fail
-	err = receiver.Start()
+	err = receiverImpl.Start()
 	if err == nil {
 		t.Fatal("Expected Start() to fail")
 	}
 
 	// Verify receiver is terminated
-	if !receiver.IsTerminated() {
+	if !receiverImpl.IsTerminated() {
 		t.Error("Receiver should be terminated after failed start")
 	}
 
@@ -1244,16 +1247,10 @@ func TestPersistentReceiverMultipleFailedStartsNoLeak(t *testing.T) {
 		t.Error("Flow was not destroyed")
 	}
 
-	// Force GC to clean up any remaining references
-	runtime.GC()
-
-	// Verify no goroutine leak
-	finalGoroutines := runtime.NumGoroutine()
-	goroutineDiff := finalGoroutines - initialGoroutines
-	if goroutineDiff != 0 {
-		t.Errorf("Goroutine leak detected: started with %d, ended with %d (diff: %d)",
-			initialGoroutines, finalGoroutines, goroutineDiff)
+    // Verify buffer channel is closed by checking the atomic flag.
+    // This proves cleanupConstructionResources() was called, which also
+    // terminates the event executor (called before closing the buffer)
+	if atomic.LoadInt32(&receiverImpl.bufferClosed) != 1 {
+		t.Error("Buffer channel should be closed")
 	}
-
-	t.Logf("Goroutine count: initial=%d, final=%d, diff=%d", initialGoroutines, finalGoroutines, goroutineDiff)
 }

--- a/test/helpers/semp_helpers.go
+++ b/test/helpers/semp_helpers.go
@@ -19,6 +19,7 @@ package helpers
 import (
 	"time"
 
+	. "github.com/onsi/gomega"
 	"solace.dev/go/messaging/test/sempclient/config"
 	"solace.dev/go/messaging/test/testcontext"
 )
@@ -212,4 +213,21 @@ func EnsureDeleteDomainCertAuthority(certAuthName string) error {
 		}
 	}
 	return nil
+}
+
+// Creates a queue with egress disabled (shutdown state),
+// causing flow creation to fail with QueueShutdown
+func CreateQueueWithEgressDisabled(queueName string) {
+	_, _, err := testcontext.SEMP().Config().QueueApi.CreateMsgVpnQueue(
+		testcontext.SEMP().ConfigCtx(),
+		config.MsgVpnQueue{
+			QueueName:      queueName,
+			IngressEnabled: True,
+			EgressEnabled:  False,
+			Owner:          "default",
+		},
+		testcontext.Messaging().VPN,
+		nil,
+	)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred(), "Failed to create queue with egress disabled: "+queueName)
 }

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -2364,4 +2364,76 @@ var _ = Describe("PersistentReceiver", func() {
 			})
 		})
 	})
+
+	Describe("Running receiver remains functional when another receiver fails to start", func() {
+		const shutdownQueueName = "shutdown_queue"
+		const workingQueueName = "working_queue"
+		const testTopic = "test"
+
+		var messagingService solace.MessagingService
+
+		BeforeEach(func() {
+			messagingService = helpers.BuildMessagingService(
+				messaging.NewMessagingServiceBuilder().FromConfigurationProvider(helpers.DefaultConfiguration()),
+			)
+			helpers.CreateQueueWithEgressDisabled(shutdownQueueName)
+			helpers.CreateQueue(workingQueueName, testTopic)
+		})
+
+		AfterEach(func() {
+			if messagingService != nil && messagingService.IsConnected() {
+				messagingService.Disconnect()
+			}
+			helpers.DeleteQueue(shutdownQueueName)
+			helpers.DeleteQueue(workingQueueName)
+		})
+
+		It("should continue to receive messages on a healthy receiver after another receiver fails to start", func() {
+            err := messagingService.Connect()
+            Expect(err).ToNot(HaveOccurred())
+
+            shutdownQueue := resource.QueueDurableNonExclusive(shutdownQueueName)
+            workingQueue := resource.QueueDurableNonExclusive(workingQueueName)
+
+            By("Starting a working receiver on a healthy queue")
+            workingReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
+                WithMessageClientAcknowledgement().
+                Build(workingQueue)
+            Expect(buildErr).ToNot(HaveOccurred())
+
+            startErr := workingReceiver.Start()
+            Expect(startErr).ToNot(HaveOccurred())
+            Expect(workingReceiver.IsRunning()).To(BeTrue())
+
+            messageReceived := make(chan message.InboundMessage, 10)
+            workingReceiver.ReceiveAsync(func(msg message.InboundMessage) {
+                messageReceived <- msg
+            })
+
+            By("Failing to start a receiver on a shutdown queue")
+            shutdownReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
+                Build(shutdownQueue)
+            Expect(buildErr).ToNot(HaveOccurred())
+
+            startErr = shutdownReceiver.Start()
+            Expect(startErr).To(HaveOccurred())
+
+            By("Publishing and receiving messages to verify the working receiver is unaffected")
+            messagesCount := 5
+            for i := 0; i < messagesCount; i++ {
+                helpers.PublishOneMessage(messagingService, testTopic)
+            }
+
+            for i := 0; i < messagesCount; i++ {
+                select {
+                case <-messageReceived:
+                case <-time.After(5 * time.Second):
+                    Fail(fmt.Sprintf("Timed out waiting for message %d/%d", i+1, messagesCount))
+                }
+            }
+
+            termErr := workingReceiver.Terminate(5 * time.Second)
+            Expect(termErr).ToNot(HaveOccurred())
+        })
+	})
 })


### PR DESCRIPTION
# Overview
  When `PersistentMessageReceiver.Start()` fails, resources allocated during construction are not freed:
  - Event executor goroutine continues running
  - Buffer channel remains open
  - Internal flow not destroyed

  This create memory leaks

# Fix
  **New helper methods:**
  - cleanupConstructionResources() - terminates executor and closes buffer (construction scope)
  - cleanupStartResources() - removes event handler and destroys flow (start scope)
  - cleanupRuntimeSubscriptions() - clears subscription correlations (runtime scope)
  - destroyInternalFlow() - destroys flow with error logging

  **Changes:**
  - Start() - Added defer block that calls both cleanup methods on error
  - Terminate() - Refactored to use new cleanup methods
  - unsolicitedTermination() - Calls cleanupConstructionResources()

# Testing
  Added TestPersistentReceiverMultipleFailedStartsNoLeak which verifies:
  1. Flow is destroyed when start fails
  2. Receiver transitions to terminated state
  3. Buffer channel is closed (via bufferClosed atomic flag check)