### PR TITLE
EBP-1981:  Update existing integration test with state assertions

### DIFF
--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -2404,6 +2404,7 @@ var _ = Describe("PersistentReceiver", func() {
 			startErr := workingReceiver.Start()
 			Expect(startErr).ToNot(HaveOccurred())
 			Expect(workingReceiver.IsRunning()).To(BeTrue())
+			Expect(workingReceiver.IsTerminated()).To(BeFalse())
 
 			messageReceived := make(chan message.InboundMessage, 10)
 			workingReceiver.ReceiveAsync(func(msg message.InboundMessage) {
@@ -2429,14 +2430,17 @@ var _ = Describe("PersistentReceiver", func() {
 				Build(shutdownQueue)
 			Expect(buildErr).ToNot(HaveOccurred())
 			Expect(shutdownReceiver.IsRunning()).To(BeFalse())
+			Expect(shutdownReceiver.IsTerminated()).To(BeFalse())
 
 			startErr = shutdownReceiver.Start()
 			Expect(startErr).To(HaveOccurred())
 			Expect(shutdownReceiver.IsRunning()).To(BeFalse())
+			Expect(shutdownReceiver.IsTerminated()).To(BeTrue())
 			Expect(messagingService.IsConnected()).To(BeTrue())
 
 			By("Verifying the working receiver is unaffected after the second receiver fails to start")
 			Expect(workingReceiver.IsRunning()).To(BeTrue())
+			Expect(workingReceiver.IsTerminated()).To(BeFalse())
 			for i := 0; i < messagesCount; i++ {
 				helpers.PublishOneMessage(messagingService, testTopic)
 			}
@@ -2451,6 +2455,7 @@ var _ = Describe("PersistentReceiver", func() {
 			termErr := workingReceiver.Terminate(5 * time.Second)
 			Expect(termErr).ToNot(HaveOccurred())
 			Expect(workingReceiver.IsRunning()).To(BeFalse())
+			Expect(workingReceiver.IsTerminated()).To(BeTrue())
 		})
 	})
 })

--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -2389,51 +2389,68 @@ var _ = Describe("PersistentReceiver", func() {
 		})
 
 		It("should continue to receive messages on a healthy receiver after another receiver fails to start", func() {
-            err := messagingService.Connect()
-            Expect(err).ToNot(HaveOccurred())
+			err := messagingService.Connect()
+			Expect(err).ToNot(HaveOccurred())
 
-            shutdownQueue := resource.QueueDurableNonExclusive(shutdownQueueName)
-            workingQueue := resource.QueueDurableNonExclusive(workingQueueName)
+			shutdownQueue := resource.QueueDurableNonExclusive(shutdownQueueName)
+			workingQueue := resource.QueueDurableNonExclusive(workingQueueName)
 
-            By("Starting a working receiver on a healthy queue")
-            workingReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
-                WithMessageClientAcknowledgement().
-                Build(workingQueue)
-            Expect(buildErr).ToNot(HaveOccurred())
+			By("Starting a working receiver on a healthy queue")
+			workingReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
+				WithMessageClientAcknowledgement().
+				Build(workingQueue)
+			Expect(buildErr).ToNot(HaveOccurred())
 
-            startErr := workingReceiver.Start()
-            Expect(startErr).ToNot(HaveOccurred())
-            Expect(workingReceiver.IsRunning()).To(BeTrue())
+			startErr := workingReceiver.Start()
+			Expect(startErr).ToNot(HaveOccurred())
+			Expect(workingReceiver.IsRunning()).To(BeTrue())
 
-            messageReceived := make(chan message.InboundMessage, 10)
-            workingReceiver.ReceiveAsync(func(msg message.InboundMessage) {
-                messageReceived <- msg
-            })
+			messageReceived := make(chan message.InboundMessage, 10)
+			workingReceiver.ReceiveAsync(func(msg message.InboundMessage) {
+				messageReceived <- msg
+			})
 
-            By("Failing to start a receiver on a shutdown queue")
-            shutdownReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
-                Build(shutdownQueue)
-            Expect(buildErr).ToNot(HaveOccurred())
+			By("Publishing and receiving messages on the working receiver before the second receiver fails to start")
+			messagesCount := 5
+			for i := 0; i < messagesCount; i++ {
+				helpers.PublishOneMessage(messagingService, testTopic)
+			}
+			for i := 0; i < messagesCount; i++ {
+				select {
+				case <-messageReceived:
+				case <-time.After(5 * time.Second):
+					Fail(fmt.Sprintf("Timed out waiting for message %d/%d before second receiver start", i+1, messagesCount))
+				}
+			}
+			Expect(workingReceiver.IsRunning()).To(BeTrue())
 
-            startErr = shutdownReceiver.Start()
-            Expect(startErr).To(HaveOccurred())
+			By("Failing to start a receiver on a shutdown queue")
+			shutdownReceiver, buildErr := messagingService.CreatePersistentMessageReceiverBuilder().
+				Build(shutdownQueue)
+			Expect(buildErr).ToNot(HaveOccurred())
+			Expect(shutdownReceiver.IsRunning()).To(BeFalse())
 
-            By("Publishing and receiving messages to verify the working receiver is unaffected")
-            messagesCount := 5
-            for i := 0; i < messagesCount; i++ {
-                helpers.PublishOneMessage(messagingService, testTopic)
-            }
+			startErr = shutdownReceiver.Start()
+			Expect(startErr).To(HaveOccurred())
+			Expect(shutdownReceiver.IsRunning()).To(BeFalse())
+			Expect(messagingService.IsConnected()).To(BeTrue())
 
-            for i := 0; i < messagesCount; i++ {
-                select {
-                case <-messageReceived:
-                case <-time.After(5 * time.Second):
-                    Fail(fmt.Sprintf("Timed out waiting for message %d/%d", i+1, messagesCount))
-                }
-            }
+			By("Verifying the working receiver is unaffected after the second receiver fails to start")
+			Expect(workingReceiver.IsRunning()).To(BeTrue())
+			for i := 0; i < messagesCount; i++ {
+				helpers.PublishOneMessage(messagingService, testTopic)
+			}
+			for i := 0; i < messagesCount; i++ {
+				select {
+				case <-messageReceived:
+				case <-time.After(5 * time.Second):
+					Fail(fmt.Sprintf("Timed out waiting for message %d/%d after second receiver failed to start", i+1, messagesCount))
+				}
+			}
 
-            termErr := workingReceiver.Terminate(5 * time.Second)
-            Expect(termErr).ToNot(HaveOccurred())
-        })
+			termErr := workingReceiver.Terminate(5 * time.Second)
+			Expect(termErr).ToNot(HaveOccurred())
+			Expect(workingReceiver.IsRunning()).To(BeFalse())
+		})
 	})
 })


### PR DESCRIPTION
# Overview:

  1. Connect the messaging service.
  2. Build and start workingReceiver on the healthy queue; assert it is running and not terminated.
  3. Publish 5 messages and verify all 5 are received within 5 seconds
  4. Assert workingReceiver is still running
  5. Build shutdownReceiver on the egress-disabled queue; assert it is neither running nor terminated (pre-start state is clean).
  6. Attempt to start shutdownReceiver — assert the start returns an error, the receiver is not running, and its state transitions to terminated.
  7. Assert the messaging service remains connected (the failed start does not tear down the session).
  8. Assert workingReceiver is still running and not terminated after the neighbour's failure.
  9. Publish another 5 messages and verify all 5 are received within 5 seconds — proves the flow and async callbacks were not corrupted by the failed start.
  10. Terminate workingReceiver; assert it is no longer running and is terminated.