### PR TITLE
EBP-2398: Dynamically resolve the host name for Persistent Receiver tests

### DIFF
--- a/test/persistent_receiver_test.go
+++ b/test/persistent_receiver_test.go
@@ -740,11 +740,13 @@ var _ = Describe("PersistentReceiver", func() {
 					Expect(subscriptions).To(ContainElement(topicString))
 				})
 				It("fails to add the queue topic subscription to the queue", func() {
-					err := receiver.AddSubscription(resource.TopicSubscriptionOf("#P2P/QUE/v:solbroker/" + queueName))
+					hostName, _ := helpers.GetHostName(messagingService, queueName+"_tmp")
+					err := receiver.AddSubscription(resource.TopicSubscriptionOf("#P2P/QUE/v:" + hostName + "/" + queueName))
 					helpers.ValidateNativeError(err, subcode.PermissionNotAllowed)
 				})
 				It("fails to remove the queue topic subscription from the queue", func() {
-					err := receiver.RemoveSubscription(resource.TopicSubscriptionOf("#P2P/QUE/v:solbroker/" + queueName))
+					hostName, _ := helpers.GetHostName(messagingService, queueName+"_tmp")
+					err := receiver.RemoveSubscription(resource.TopicSubscriptionOf("#P2P/QUE/v:" + hostName + "/" + queueName))
 					helpers.ValidateNativeError(err, subcode.PermissionNotAllowed)
 				})
 				It("fails to add an invalid subscription", func() {


### PR DESCRIPTION
#Overview

The tests` fails to add/remove the queue topic subscription to the queue` were hardcoding `v:solbroker` as the broker hostname in the `#P2P/QUE/ `topic string. On Linux CI the broker container hostname      
  happens to be `solbroker`, so the broker recognized the topic as its own queue's P2P address and correctly rejected it with PermissionNotAllowed. On darwin, the broker has a different hostname, so it
  didn't recognize the topic as reserved and accepted the subscription — returning nil instead of an error, causing the test to fail.                                                             
                                                                                                                                                                                                           
  Fixed by using the existing `GetHostName` helper to dynamically resolve the broker's actual hostname
  
  # Testing

Jenkins build don't show any Persistent Receiver errors
https://jenkins2.solacedev.net/job/solacedev.pubsubplus-go-client/job/EBP-2398/